### PR TITLE
feat: bootstrap rawspeak MVP pipeline and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,162 @@
+# rawspeak
+
+Even if you speak messy, it understands you and writes it cleanly — optimized for AI prompts.
+
+A free, privacy-first local voice-to-text desktop tool.  
+Press a hotkey → record your voice → get clean, ready-to-paste text.
+
+---
+
+## Features
+
+| Feature | Details |
+|---|---|
+| **Global hotkey toggle** | Press once to start recording, press again to stop |
+| **Local Whisper transcription** | Runs entirely on your machine via HuggingFace `transformers` |
+| **LLM text cleanup** | Removes filler words, fixes grammar, reformats for AI prompts |
+| **Auto-paste** | Injects the cleaned text into whatever app is currently focused |
+| **System tray icon** | Green = idle · Red = listening · Blue = processing |
+| **100 % offline** | Optionally uses Groq free tier for cleanup; everything else is local |
+
+---
+
+## Quick start
+
+### 1. Install system dependencies
+
+**macOS**
+```bash
+brew install portaudio
+```
+
+**Ubuntu / Debian**
+```bash
+sudo apt install portaudio19-dev python3-tk
+```
+
+**Windows** — PortAudio ships with the `sounddevice` wheel; no extra step needed.
+
+### 2. Install rawspeak
+
+```bash
+pip install rawspeak
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/uopx-engineering/rawspeak
+cd rawspeak
+pip install -e .
+```
+
+### 3. (Optional) Install a local LLM via Ollama
+
+```bash
+# macOS / Linux
+curl https://ollama.com/install.sh | sh
+ollama pull llama3.2:3b
+```
+
+rawspeak talks to Ollama automatically.  
+If Ollama isn't running, cleanup falls back to a fast rule-based pass.
+
+### 4. Run
+
+```bash
+rawspeak
+```
+
+A tray icon appears. Press **Ctrl + Alt + Space** to toggle recording.
+
+---
+
+## Configuration
+
+On first run rawspeak writes a config file at:
+
+- **Linux/macOS:** `~/.config/rawspeak/config.toml`
+- **Windows:** `%USERPROFILE%\.config\rawspeak\config.toml`
+
+```toml
+# Global hotkey to toggle recording.
+hotkey = "<ctrl>+<alt>+<space>"
+
+# Whisper model (tiny < base < small — smaller = faster).
+whisper_model = "openai/whisper-base"
+
+# Cleanup backend: "ollama" | "groq" | "none"
+cleanup_backend = "ollama"
+
+# Ollama (local LLM)
+ollama_url   = "http://localhost:11434"
+ollama_model = "llama3.2:3b"
+
+# Groq (free cloud API — set GROQ_API_KEY env var or add key here)
+# groq_api_key = "gsk_..."
+groq_model = "llama-3.1-8b-instant"
+```
+
+### Groq API key
+
+```bash
+export GROQ_API_KEY="gsk_..."
+rawspeak
+```
+
+Or set `groq_api_key` in the config file and set `cleanup_backend = "groq"`.
+
+---
+
+## Architecture
+
+```
+hotkey press
+    │
+    ▼
+AudioRecorder          (sounddevice — 16 kHz mono float32)
+    │  audio array
+    ▼
+Transcriber            (HuggingFace transformers + openai/whisper-base)
+    │  raw text
+    ▼
+TextCleaner            (Ollama → Groq → rule-based fallback)
+    │  cleaned text
+    ▼
+Paster                 (pyperclip clipboard + pyautogui Ctrl+V)
+    │
+    ▼
+active application
+```
+
+### Module overview
+
+| Module | Responsibility |
+|---|---|
+| `rawspeak/config.py` | TOML config + environment-variable overrides |
+| `rawspeak/audio.py` | Microphone capture (`AudioRecorder`) |
+| `rawspeak/transcriber.py` | Whisper ASR (`Transcriber`) |
+| `rawspeak/cleaner.py` | LLM / rule-based cleanup (`TextCleaner`) |
+| `rawspeak/paste.py` | Clipboard injection + Ctrl+V (`Paster`) |
+| `rawspeak/hotkey.py` | Global hotkey listener (`HotkeyListener`) |
+| `rawspeak/tray.py` | System-tray icon (`TrayApp`) |
+| `rawspeak/main.py` | Orchestrator + CLI entry point (`RawSpeak`) |
+
+---
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+---
+
+## Roadmap (post-v1)
+
+- [ ] macOS paste via `pbpaste` / accessibility API
+- [ ] Voice shortcuts
+- [ ] Personal vocabulary / dictionary
+- [ ] Multi-language support
+- [ ] GPU acceleration flag in config

--- a/rawspeak/audio.py
+++ b/rawspeak/audio.py
@@ -1,0 +1,89 @@
+"""Microphone audio recording using sounddevice."""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+import numpy as np
+
+
+class AudioRecorder:
+    """Records audio from the microphone.
+
+    Usage::
+
+        recorder = AudioRecorder()
+        recorder.start()          # begin capturing
+        audio = recorder.stop()   # returns float32 numpy array at *sample_rate* Hz
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        device: Optional[str] = None,
+    ) -> None:
+        self.sample_rate = sample_rate
+        self.channels = channels
+        self.device = device
+
+        self._chunks: list[np.ndarray] = []
+        self._recording = False
+        self._stream = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Open the audio stream and start capturing."""
+        import sounddevice as sd
+
+        self._chunks = []
+        self._recording = True
+
+        def _callback(indata: np.ndarray, frames: int, time: object, status: object) -> None:
+            if self._recording:
+                with self._lock:
+                    self._chunks.append(indata.copy())
+
+        self._stream = sd.InputStream(
+            samplerate=self.sample_rate,
+            channels=self.channels,
+            dtype="float32",
+            device=self.device,
+            callback=_callback,
+        )
+        self._stream.start()
+
+    def stop(self) -> np.ndarray:
+        """Stop capturing and return the recorded audio as a float32 array.
+
+        Returns:
+            1-D float32 numpy array of mono audio samples.
+            Returns an empty array if nothing was recorded.
+        """
+        self._recording = False
+
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+
+        with self._lock:
+            if not self._chunks:
+                return np.zeros(0, dtype=np.float32)
+            audio = np.concatenate(self._chunks, axis=0)
+
+        # Collapse multi-channel audio to mono.
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+
+        return audio.astype(np.float32)
+
+    @property
+    def is_recording(self) -> bool:
+        """True while the recorder is actively capturing."""
+        return self._recording

--- a/rawspeak/cleaner.py
+++ b/rawspeak/cleaner.py
@@ -1,0 +1,161 @@
+"""LLM-based text cleanup for transcribed speech."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompt sent to the LLM
+# ---------------------------------------------------------------------------
+
+_CLEANUP_PROMPT = (
+    "Clean up the following transcribed speech. "
+    "Remove filler words (um, uh, like, you know, sort of, kind of, basically, "
+    "literally, actually when used as filler), fix grammar and punctuation, "
+    "remove false starts and repetitions, and make the text read as clearly typed "
+    "prose suitable for use as an AI prompt. Preserve the original meaning. "
+    "Return ONLY the cleaned text — no explanation, no preamble.\n\n"
+    "Transcription: {text}"
+)
+
+
+class TextCleaner:
+    """Cleans up transcribed text using an LLM or a rule-based fallback.
+
+    Backend priority:
+
+    * ``"ollama"`` — calls a local Ollama server; falls back to rule-based on error.
+    * ``"groq"``   — calls the Groq API;  falls back to rule-based on error.
+    * ``"none"``   — rule-based only (no network requests).
+    """
+
+    def __init__(
+        self,
+        backend: str = "ollama",
+        ollama_url: str = "http://localhost:11434",
+        ollama_model: str = "llama3.2:3b",
+        groq_api_key: str = "",
+        groq_model: str = "llama-3.1-8b-instant",
+    ) -> None:
+        self.backend = backend
+        self.ollama_url = ollama_url.rstrip("/")
+        self.ollama_model = ollama_model
+        self.groq_api_key = groq_api_key
+        self.groq_model = groq_model
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def clean(self, text: str) -> str:
+        """Return a cleaned version of *text*.
+
+        Falls back to rule-based cleanup when the configured backend fails.
+        """
+        if not text.strip():
+            return text
+
+        if self.backend == "ollama":
+            try:
+                return self._clean_ollama(text)
+            except Exception as exc:
+                logger.warning("Ollama cleanup failed (%s); using rule-based fallback", exc)
+                return _rule_based_clean(text)
+
+        if self.backend == "groq":
+            try:
+                return self._clean_groq(text)
+            except Exception as exc:
+                logger.warning("Groq cleanup failed (%s); using rule-based fallback", exc)
+                return _rule_based_clean(text)
+
+        return _rule_based_clean(text)
+
+    # ------------------------------------------------------------------
+    # Backend implementations
+    # ------------------------------------------------------------------
+
+    def _clean_ollama(self, text: str) -> str:
+        """Send *text* to a local Ollama server and return the response."""
+        url = f"{self.ollama_url}/api/generate"
+        payload = {
+            "model": self.ollama_model,
+            "prompt": _CLEANUP_PROMPT.format(text=text),
+            "stream": False,
+        }
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+        return result.get("response", text).strip()
+
+    def _clean_groq(self, text: str) -> str:
+        """Send *text* to the Groq chat-completions API and return the response."""
+        if not self.groq_api_key:
+            raise ValueError("Groq API key not configured")
+
+        url = "https://api.groq.com/openai/v1/chat/completions"
+        payload = {
+            "model": self.groq_model,
+            "messages": [
+                {"role": "user", "content": _CLEANUP_PROMPT.format(text=text)},
+            ],
+            "temperature": 0.3,
+            "max_tokens": 1024,
+        }
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.groq_api_key}",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+        return result["choices"][0]["message"]["content"].strip()
+
+
+# ---------------------------------------------------------------------------
+# Rule-based fallback
+# ---------------------------------------------------------------------------
+
+# Filler patterns to remove unconditionally.
+_FILLER_PATTERNS = [
+    r"\bum+\b",
+    r"\buh+\b",
+    r"\byou\s+know\b",
+    r"\bI\s+mean\b(?:,\s*)?",
+]
+
+_FILLER_RE = re.compile(
+    "|".join(_FILLER_PATTERNS),
+    flags=re.IGNORECASE,
+)
+
+
+def _rule_based_clean(text: str) -> str:
+    """Remove common speech fillers and tidy whitespace."""
+    result = _FILLER_RE.sub("", text)
+    # Collapse multiple spaces.
+    result = re.sub(r"\s{2,}", " ", result)
+    # Remove spaces before punctuation.
+    result = re.sub(r"\s+([.,!?;:])", r"\1", result)
+    result = result.strip()
+    # Capitalise the first character.
+    if result:
+        result = result[0].upper() + result[1:]
+    return result

--- a/rawspeak/config.py
+++ b/rawspeak/config.py
@@ -1,0 +1,129 @@
+"""Configuration management for rawspeak."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Python 3.11+ includes tomllib in stdlib; older versions need tomli.
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib  # type: ignore[no-redef]
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            tomllib = None  # type: ignore[assignment]
+
+CONFIG_DIR = Path.home() / ".config" / "rawspeak"
+CONFIG_FILE = CONFIG_DIR / "config.toml"
+
+DEFAULT_CONFIG_TOML = """\
+# rawspeak configuration
+# Edit this file to customise rawspeak behaviour.
+
+# Global hotkey to toggle recording.
+# Examples: "<ctrl>+<alt>+<space>", "<ctrl>+<shift>+r"
+hotkey = "<ctrl>+<alt>+<space>"
+
+# Optional mouse button that also toggles recording.
+# Values: "middle" (scroll-wheel click), "x1", "x2", or "" to disable.
+mouse_button = "middle"
+
+# Audio capture settings.
+sample_rate = 16000  # Hz — Whisper expects 16 kHz
+channels    = 1      # Mono
+
+# HuggingFace Whisper model identifier.
+# Smaller = faster; larger = more accurate.
+# Options: "openai/whisper-tiny", "openai/whisper-base", "openai/whisper-small"
+whisper_model = "openai/whisper-base"
+
+# Spoken language for transcription (ISO 639-1 code, e.g. "en").
+# Forces Whisper to skip language detection and transcribe directly in this language,
+# which is faster and avoids hallucination on background noise.
+language = "en"
+
+# Text-cleanup backend: "ollama" | "groq" | "none"
+cleanup_backend = "ollama"
+
+# Ollama settings (used when cleanup_backend = "ollama").
+ollama_url   = "http://localhost:11434"
+ollama_model = "llama3.2:3b"
+
+# Groq settings (used when cleanup_backend = "groq").
+# Set your key here or via the GROQ_API_KEY environment variable.
+# groq_api_key = "gsk_..."
+groq_model = "llama-3.1-8b-instant"
+
+# Show a desktop notification after each successful paste.
+show_notifications = true
+"""
+
+
+@dataclass
+class Config:
+    # Hotkey
+    hotkey: str = "<ctrl>+<alt>+<space>"
+    mouse_button: str = "middle"  # scroll-wheel click; "" to disable
+
+    # Audio
+    sample_rate: int = 16000
+    channels: int = 1
+    device: Optional[str] = None  # None → system default
+
+    # Transcription
+    whisper_model: str = "openai/whisper-base"
+    language: str = "en"
+
+    # Cleanup
+    cleanup_backend: str = "ollama"
+
+    # Ollama
+    ollama_url: str = "http://localhost:11434"
+    ollama_model: str = "llama3.2:3b"
+
+    # Groq
+    groq_api_key: str = ""
+    groq_model: str = "llama-3.1-8b-instant"
+
+    # UI
+    show_notifications: bool = True
+
+
+def load_config() -> Config:
+    """Load configuration, merging file values on top of defaults."""
+    config = Config()
+
+    # Environment variable overrides.
+    if api_key := os.environ.get("GROQ_API_KEY"):
+        config.groq_api_key = api_key
+
+    if not CONFIG_FILE.exists():
+        return config
+
+    if tomllib is None:
+        return config
+
+    try:
+        with open(CONFIG_FILE, "rb") as fh:
+            data = tomllib.load(fh)
+        for key, value in data.items():
+            if hasattr(config, key):
+                setattr(config, key, value)
+    except Exception:
+        pass  # silently use defaults if the file is malformed
+
+    return config
+
+
+def write_default_config() -> None:
+    """Write a starter config file if none exists yet."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if not CONFIG_FILE.exists():
+        CONFIG_FILE.write_text(DEFAULT_CONFIG_TOML)

--- a/rawspeak/hotkey.py
+++ b/rawspeak/hotkey.py
@@ -1,0 +1,89 @@
+"""Global hotkey listener using *pynput*."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HotkeyListener:
+    """Listens for a global hotkey combination and calls a callback on each activation.
+
+    Optionally also listens for a mouse button (e.g. scroll-wheel / middle click)
+    as an additional trigger.  The toggle logic (start/stop recording) is
+    intentionally left to the caller so that this class stays a thin wrapper
+    around *pynput*.
+    """
+
+    def __init__(
+        self,
+        hotkey: str,
+        on_activate: Callable[[], None],
+        mouse_button: str = "",
+    ) -> None:
+        """
+        Args:
+            hotkey: Hotkey string in pynput ``GlobalHotKeys`` format,
+                    e.g. ``"<ctrl>+<alt>+<space>"``.
+            on_activate: Called every time the hotkey fires.
+            mouse_button: Optional pynput mouse button name that also triggers
+                          the callback (e.g. ``"middle"``).  Empty string disables.
+        """
+        self.hotkey = hotkey
+        self.on_activate = on_activate
+        self.mouse_button = mouse_button
+        self._listener = None
+        self._mouse_listener = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start listening for the hotkey (and optional mouse button) in daemon threads."""
+        from pynput import keyboard
+
+        def _safe_activate() -> None:
+            try:
+                self.on_activate()
+            except Exception:
+                logger.exception("Unhandled error in hotkey callback")
+
+        self._listener = keyboard.GlobalHotKeys({self.hotkey: _safe_activate})
+        self._listener.start()
+        logger.debug("Hotkey listener started for %r", self.hotkey)
+
+        if self.mouse_button:
+            self._start_mouse_listener(_safe_activate)
+
+    def _start_mouse_listener(self, callback: Callable[[], None]) -> None:
+        """Start a mouse listener that fires *callback* on the configured button press."""
+        from pynput import mouse
+
+        target_button = getattr(mouse.Button, self.mouse_button, None)
+        if target_button is None:
+            logger.warning(
+                "Unknown mouse_button %r — mouse trigger disabled", self.mouse_button
+            )
+            return
+
+        def _on_click(x: int, y: int, button: mouse.Button, pressed: bool) -> None:
+            if pressed and button == target_button:
+                callback()
+
+        self._mouse_listener = mouse.Listener(on_click=_on_click)
+        self._mouse_listener.daemon = True
+        self._mouse_listener.start()
+        logger.debug("Mouse listener started for button %r", self.mouse_button)
+
+    def stop(self) -> None:
+        """Stop the hotkey and mouse listeners."""
+        if self._listener is not None:
+            self._listener.stop()
+            self._listener = None
+        if self._mouse_listener is not None:
+            self._mouse_listener.stop()
+            self._mouse_listener = None
+        logger.debug("Hotkey listener stopped")

--- a/rawspeak/launcher.py
+++ b/rawspeak/launcher.py
@@ -1,0 +1,119 @@
+"""Install / uninstall rawspeak as a macOS LaunchAgent (auto-start at login)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_PLIST_LABEL = "com.rawspeak.agent"
+_PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{_PLIST_LABEL}.plist"
+
+_PLIST_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{executable}</string>
+    </array>
+
+    <!-- Restart automatically if it crashes -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Start as soon as the user logs in -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Write stdout / stderr to ~/Library/Logs/rawspeak.log -->
+    <key>StandardOutPath</key>
+    <string>{log}</string>
+    <key>StandardErrorPath</key>
+    <string>{log}</string>
+</dict>
+</plist>
+"""
+
+
+def _rawspeak_executable() -> str:
+    """Return the absolute path to the rawspeak console script.
+
+    Prefers the executable sitting next to the current Python interpreter
+    (i.e. inside the active virtual-env's bin/) so the LaunchAgent uses the
+    same environment that was set up with `pip install -e .`.
+    """
+    candidate = Path(sys.executable).parent / "rawspeak"
+    if candidate.exists():
+        return str(candidate)
+    # Fall back to whatever is on PATH.
+    found = shutil.which("rawspeak")
+    if found:
+        return found
+    raise FileNotFoundError(
+        "Could not locate the rawspeak executable. "
+        "Make sure rawspeak is installed (`pip install -e .`) before running `rawspeak install`."
+    )
+
+
+def install() -> None:
+    """Write a LaunchAgent plist and load it so rawspeak starts now and at every login."""
+    if sys.platform != "darwin":
+        print("Auto-start via LaunchAgent is only supported on macOS.")
+        sys.exit(1)
+
+    executable = _rawspeak_executable()
+    log_path = Path.home() / "Library" / "Logs" / "rawspeak.log"
+
+    _PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _PLIST_PATH.write_text(
+        _PLIST_TEMPLATE.format(
+            label=_PLIST_LABEL,
+            executable=executable,
+            log=log_path,
+        )
+    )
+
+    # Unload first in case a stale entry exists, then load the new one.
+    subprocess.run(
+        ["launchctl", "unload", str(_PLIST_PATH)],
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["launchctl", "load", "-w", str(_PLIST_PATH)],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"launchctl load failed:\n{result.stderr.strip()}")
+        sys.exit(1)
+
+    print(f"rawspeak installed as a login item.")
+    print(f"  Plist : {_PLIST_PATH}")
+    print(f"  Log   : {log_path}")
+    print(f"rawspeak is now running in the background — hotkey is active.")
+
+
+def uninstall() -> None:
+    """Unload and remove the LaunchAgent plist."""
+    if sys.platform != "darwin":
+        print("Auto-start via LaunchAgent is only supported on macOS.")
+        sys.exit(1)
+
+    if not _PLIST_PATH.exists():
+        print("rawspeak is not installed as a login item.")
+        return
+
+    subprocess.run(
+        ["launchctl", "unload", "-w", str(_PLIST_PATH)],
+        capture_output=True,
+    )
+    _PLIST_PATH.unlink()
+    print("rawspeak removed from login items and stopped.")

--- a/rawspeak/main.py
+++ b/rawspeak/main.py
@@ -1,0 +1,219 @@
+"""Main entry point — wires all components together."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+
+from .audio import AudioRecorder
+from .cleaner import TextCleaner
+from .config import load_config, write_default_config
+from .hotkey import HotkeyListener
+from .paste import Paster
+from .transcriber import Transcriber
+from .tray import TrayApp
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+class RawSpeak:
+    """Orchestrates the full voice-to-text pipeline.
+
+    State machine::
+
+        idle  ──hotkey──►  listening  ──hotkey──►  processing  ──done──►  idle
+    """
+
+    def __init__(self) -> None:
+        self.config = load_config()
+        write_default_config()
+
+        self.recorder = AudioRecorder(
+            sample_rate=self.config.sample_rate,
+            channels=self.config.channels,
+            device=self.config.device,
+        )
+        self.transcriber = Transcriber(
+            model_name=self.config.whisper_model,
+            language=self.config.language,
+        )
+        self.cleaner = TextCleaner(
+            backend=self.config.cleanup_backend,
+            ollama_url=self.config.ollama_url,
+            ollama_model=self.config.ollama_model,
+            groq_api_key=self.config.groq_api_key,
+            groq_model=self.config.groq_model,
+        )
+        self.paster = Paster()
+        self.tray = TrayApp(on_quit=self._quit)
+        self.hotkey = HotkeyListener(
+            hotkey=self.config.hotkey,
+            on_activate=self._on_hotkey,
+            mouse_button=self.config.mouse_button,
+        )
+
+        self._recording = False
+        self._processing = False
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Hotkey handler
+    # ------------------------------------------------------------------
+
+    def _on_hotkey(self) -> None:
+        """Toggle recording on/off each time the hotkey fires."""
+        with self._lock:
+            if self._processing:
+                return  # ignore while pipeline is running
+
+            if not self._recording:
+                self._start_recording()
+            else:
+                self._stop_and_process()
+
+    def _start_recording(self) -> None:
+        """Begin capturing audio (called with _lock held)."""
+        try:
+            self.recorder.start()
+        except Exception:
+            logger.exception("Failed to start audio recording")
+            return
+        self._recording = True
+        logger.info("Recording started — press the hotkey again to stop")
+        self.tray.set_state("listening")
+
+    def _stop_and_process(self) -> None:
+        """Stop recording and kick off the pipeline (called with _lock held)."""
+        self._recording = False
+        self._processing = True
+        logger.info("Recording stopped — processing audio…")
+        self.tray.set_state("processing")
+        thread = threading.Thread(
+            target=self._run_pipeline, daemon=True, name="rawspeak-pipeline"
+        )
+        thread.start()
+
+    # ------------------------------------------------------------------
+    # Pipeline
+    # ------------------------------------------------------------------
+
+    def _run_pipeline(self) -> None:
+        """Transcribe → clean → paste.  Always resets state on exit."""
+        try:
+            audio = self.recorder.stop()
+
+            duration = len(audio) / self.config.sample_rate
+            if duration < 0.2:
+                logger.info("Recording too short (%.2f s) — ignoring", duration)
+                return
+
+            logger.info("Transcribing %.1f s of audio…", duration)
+            text = self.transcriber.transcribe(audio, self.config.sample_rate)
+            logger.info("Raw transcription: %r", text)
+
+            if not text.strip():
+                logger.info("Empty transcription — nothing to paste")
+                return
+
+            logger.info("Cleaning up text…")
+            cleaned = self.cleaner.clean(text)
+            logger.info("Cleaned text: %r", cleaned)
+
+            logger.info("Pasting…")
+            self.paster.paste(cleaned)
+            logger.info("Done!")
+
+        except Exception:
+            logger.exception("Error in pipeline")
+        finally:
+            with self._lock:
+                self._processing = False
+            self.tray.set_state("idle")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _quit(self) -> None:
+        """Cleanly shut down all components."""
+        logger.info("Shutting down rawspeak")
+        self._stop_event.set()
+        if self.recorder.is_recording:
+            self.recorder.stop()
+        self.hotkey.stop()
+        sys.exit(0)
+
+    def run(self) -> None:
+        """Start the application and block until the user quits."""
+        logger.info(
+            "rawspeak ready  |  hotkey: %s  |  model: %s  |  cleanup: %s",
+            self.config.hotkey,
+            self.config.whisper_model,
+            self.config.cleanup_backend,
+        )
+        logger.info(
+            "(The Whisper model will be downloaded on first use if not cached.)"
+        )
+
+        self.hotkey.start()
+
+        if sys.platform == "darwin":
+            # AppKit requires tray setup on the main thread on macOS.
+            try:
+                self.tray.run_blocking()
+            except KeyboardInterrupt:
+                self._quit()
+        else:
+            self.tray.start()
+            try:
+                self._stop_event.wait()
+            except KeyboardInterrupt:
+                self._quit()
+
+
+def main() -> None:
+    """CLI entry point installed by *pyproject.toml*.
+
+    Subcommands
+    -----------
+    rawspeak             — run the app (default)
+    rawspeak install     — install as a macOS login item (auto-start at login)
+    rawspeak uninstall   — remove the login item
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="rawspeak",
+        description="Local voice-to-text — hotkey to record, auto-paste cleaned text.",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="run",
+        choices=["run", "install", "uninstall"],
+        help="'install' sets up auto-start at login; 'uninstall' removes it.",
+    )
+    args = parser.parse_args()
+
+    if args.command == "install":
+        from .launcher import install
+
+        install()
+    elif args.command == "uninstall":
+        from .launcher import uninstall
+
+        uninstall()
+    else:
+        app = RawSpeak()
+        app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/rawspeak/paste.py
+++ b/rawspeak/paste.py
@@ -1,0 +1,56 @@
+"""Clipboard injection and auto-paste into the active application."""
+
+from __future__ import annotations
+
+import time
+
+
+class Paster:
+    """Copies text to the clipboard then triggers a Ctrl+V paste."""
+
+    def __init__(self, paste_delay: float = 0.1) -> None:
+        """
+        Args:
+            paste_delay: Seconds to wait after writing the clipboard before
+                         sending the paste keystroke.  A small delay is needed
+                         so the target application has time to process the
+                         clipboard write.
+        """
+        self.paste_delay = paste_delay
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def paste(self, text: str) -> None:
+        """Paste *text* into the currently focused application.
+
+        Does nothing when *text* is blank.
+        """
+        if not text.strip():
+            return
+
+        self._set_clipboard(text)
+        time.sleep(self.paste_delay)
+        self._send_paste()
+
+    # ------------------------------------------------------------------
+    # Internal helpers (split out for easy mocking in tests)
+    # ------------------------------------------------------------------
+
+    def _set_clipboard(self, text: str) -> None:
+        """Write *text* to the system clipboard."""
+        import pyperclip
+
+        pyperclip.copy(text)
+
+    def _send_paste(self) -> None:
+        """Send the platform-appropriate paste keystroke to the active window."""
+        import sys
+
+        import pyautogui
+
+        if sys.platform == "darwin":
+            pyautogui.hotkey("command", "v")
+        else:
+            pyautogui.hotkey("ctrl", "v")

--- a/rawspeak/transcriber.py
+++ b/rawspeak/transcriber.py
@@ -1,0 +1,109 @@
+"""Whisper transcription via HuggingFace *transformers*."""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+
+
+class Transcriber:
+    """Transcribes audio to text using a local Whisper model.
+
+    The model is loaded lazily on the first call to :meth:`transcribe` so that
+    startup time is kept low.
+    """
+
+    def __init__(
+        self, model_name: str = "openai/whisper-base", language: str = "en"
+    ) -> None:
+        self.model_name = model_name
+        self.language = language
+        self._pipeline = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def transcribe(self, audio: np.ndarray, sample_rate: int = 16000) -> str:
+        """Transcribe *audio* to text.
+
+        Args:
+            audio: Float32 numpy array of audio samples.
+            sample_rate: Sample rate of *audio* (Whisper expects 16 000 Hz).
+
+        Returns:
+            Transcribed text, stripped of leading/trailing whitespace.
+        """
+        if len(audio) == 0:
+            return ""
+
+        self._load_model()
+
+        if sample_rate != 16000:
+            audio = _resample(audio, sample_rate, 16000)
+
+        result = self._pipeline(
+            {"array": audio, "sampling_rate": 16000},
+            return_timestamps=True,  # required for audio > 30 s; safe for shorter audio too
+            generate_kwargs={"language": self.language, "task": "transcribe"},
+        )
+        text = result.get("text", "").strip()
+        if _is_hallucination(text):
+            return ""
+        return text
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_model(self) -> None:
+        """Lazy-load the Whisper ASR pipeline."""
+        if self._pipeline is not None:
+            return
+
+        import torch
+        from transformers import pipeline
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        self._pipeline = pipeline(
+            "automatic-speech-recognition",
+            model=self.model_name,
+            device=device,
+        )
+
+
+def _resample(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
+    """Resample *audio* from *orig_sr* to *target_sr*.
+
+    Uses *resampy* when available, otherwise falls back to linear interpolation.
+    """
+    if orig_sr == target_sr:
+        return audio
+
+    try:
+        import resampy  # type: ignore[import-untyped]
+
+        return resampy.resample(audio, orig_sr, target_sr)
+    except ImportError:
+        pass
+
+    # Naive fallback via linear interpolation.
+    target_len = int(len(audio) * target_sr / orig_sr)
+    indices = np.linspace(0, len(audio) - 1, target_len)
+    return np.interp(indices, np.arange(len(audio)), audio).astype(np.float32)
+
+
+def _is_hallucination(text: str) -> bool:
+    """Return True when the output is a repetitive Whisper hallucination.
+
+    Whisper on multilingual models (or on silence/background noise) sometimes
+    loops a single token thousands of times, e.g. ``"asa, asa, asa, ..."``.
+    We detect this by checking whether a single word makes up more than half
+    of all words in the output.
+    """
+    words = re.findall(r"\b\w+\b", text.lower())
+    if len(words) < 8:
+        return False
+    most_common_count = max(words.count(w) for w in set(words))
+    return most_common_count / len(words) > 0.5

--- a/rawspeak/tray.py
+++ b/rawspeak/tray.py
@@ -1,0 +1,113 @@
+"""System-tray icon using *pystray* + *Pillow*."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Colours for each application state.
+_IDLE_COLOR = (80, 200, 80)        # green
+_LISTENING_COLOR = (220, 60, 60)   # red
+_PROCESSING_COLOR = (60, 140, 220) # blue
+
+_ICON_SIZE = 64
+
+_STATE_META = {
+    "idle":       (_IDLE_COLOR,       "rawspeak — idle"),
+    "listening":  (_LISTENING_COLOR,  "rawspeak — listening…"),
+    "processing": (_PROCESSING_COLOR, "rawspeak — processing…"),
+}
+
+
+def _make_icon(color: tuple[int, int, int], size: int = _ICON_SIZE):
+    """Return a *Pillow* ``Image`` containing a filled circle of *color*."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    margin = 4
+    draw.ellipse(
+        [margin, margin, size - margin, size - margin],
+        fill=(*color, 255),
+    )
+    return img
+
+
+class TrayApp:
+    """Manages the system-tray icon and reacts to state changes.
+
+    The tray runs in a daemon background thread so it never blocks the main
+    application loop.
+    """
+
+    def __init__(self, on_quit: Optional[Callable[[], None]] = None) -> None:
+        self.on_quit = on_quit
+        self._icon = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Launch the tray icon in a background daemon thread."""
+        thread = threading.Thread(target=self._run, daemon=True, name="rawspeak-tray")
+        thread.start()
+
+    def run_blocking(self) -> None:
+        """Run the tray icon on the calling thread.
+
+        Must be called from the main thread on macOS because AppKit
+        (used by pystray's Darwin backend) does not permit NSWindow
+        instantiation off the main thread.
+        """
+        self._run()
+
+    def set_state(self, state: str) -> None:
+        """Update the tray icon and tooltip to reflect *state*.
+
+        Args:
+            state: One of ``"idle"``, ``"listening"``, or ``"processing"``.
+        """
+        if self._icon is None:
+            return
+        color, title = _STATE_META.get(state, (_IDLE_COLOR, "rawspeak"))
+        self._icon.icon = _make_icon(color)
+        self._icon.title = title
+
+    def stop(self) -> None:
+        """Stop the tray icon."""
+        if self._icon is not None:
+            self._icon.stop()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        try:
+            import pystray
+        except Exception as exc:
+            logger.warning("pystray not available; tray icon disabled (%s)", exc)
+            return
+
+        menu = pystray.Menu(
+            pystray.MenuItem("rawspeak", None, enabled=False),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Quit", self._on_quit),
+        )
+
+        self._icon = pystray.Icon(
+            "rawspeak",
+            _make_icon(_IDLE_COLOR),
+            "rawspeak — idle",
+            menu=menu,
+        )
+        self._icon.run()
+
+    def _on_quit(self, icon, _item) -> None:
+        icon.stop()
+        if self.on_quit:
+            self.on_quit()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,96 @@
+"""Tests for rawspeak.audio — AudioRecorder."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from rawspeak.audio import AudioRecorder
+
+
+class TestAudioRecorderStop:
+    def test_returns_empty_float32_when_no_chunks(self):
+        recorder = AudioRecorder()
+        result = recorder.stop()
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        assert len(result) == 0
+
+    def test_concatenates_chunks(self):
+        recorder = AudioRecorder(sample_rate=16000, channels=1)
+        recorder._chunks = [
+            np.ones((160, 1), dtype=np.float32),
+            np.ones((160, 1), dtype=np.float32) * 0.5,
+        ]
+        result = recorder.stop()
+        assert len(result) == 320
+        assert result.dtype == np.float32
+
+    def test_flattens_multichannel_to_mono(self):
+        recorder = AudioRecorder(sample_rate=16000, channels=2)
+        # Two-channel chunk: left=1, right=0  →  mean=0.5
+        stereo = np.zeros((160, 2), dtype=np.float32)
+        stereo[:, 0] = 1.0
+        recorder._chunks = [stereo]
+        result = recorder.stop()
+        assert result.ndim == 1
+        assert len(result) == 160
+        np.testing.assert_allclose(result, 0.5)
+
+    def test_stops_active_stream(self):
+        recorder = AudioRecorder()
+        mock_stream = MagicMock()
+        recorder._stream = mock_stream
+        recorder.stop()
+        mock_stream.stop.assert_called_once()
+        mock_stream.close.assert_called_once()
+        assert recorder._stream is None
+
+
+class TestAudioRecorderIsRecording:
+    def test_false_by_default(self):
+        recorder = AudioRecorder()
+        assert not recorder.is_recording
+
+    def test_true_after_setting_flag(self):
+        recorder = AudioRecorder()
+        recorder._recording = True
+        assert recorder.is_recording
+
+    def test_false_after_stop(self):
+        recorder = AudioRecorder()
+        recorder._recording = True
+        recorder.stop()
+        assert not recorder.is_recording
+
+
+class TestAudioRecorderStart:
+    def _make_sd_mock(self):
+        """Return (mock_sd_module, mock_stream_instance)."""
+        mock_sd = MagicMock()
+        mock_stream = MagicMock()
+        mock_sd.InputStream.return_value = mock_stream
+        return mock_sd, mock_stream
+
+    def test_start_opens_stream_and_sets_flag(self):
+        recorder = AudioRecorder()
+        mock_sd, mock_stream = self._make_sd_mock()
+
+        with patch.dict("sys.modules", {"sounddevice": mock_sd}):
+            recorder.start()
+
+        assert recorder._recording is True
+        mock_sd.InputStream.assert_called_once()
+        mock_stream.start.assert_called_once()
+
+    def test_start_clears_previous_chunks(self):
+        recorder = AudioRecorder()
+        recorder._chunks = [np.ones(10, dtype=np.float32)]
+        mock_sd, _ = self._make_sd_mock()
+
+        with patch.dict("sys.modules", {"sounddevice": mock_sd}):
+            recorder.start()
+
+        assert recorder._chunks == []

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,0 +1,107 @@
+"""Tests for rawspeak.cleaner — TextCleaner and _rule_based_clean."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rawspeak.cleaner import TextCleaner, _rule_based_clean
+
+
+class TestRuleBasedClean:
+    def test_removes_um(self):
+        assert "um" not in _rule_based_clean("um hello").lower()
+
+    def test_removes_uh(self):
+        assert "uh" not in _rule_based_clean("uh actually").lower()
+
+    def test_removes_you_know(self):
+        assert "you know" not in _rule_based_clean("you know what I mean").lower()
+
+    def test_capitalises_first_letter(self):
+        result = _rule_based_clean("hello world")
+        assert result[0].isupper()
+
+    def test_collapses_extra_spaces(self):
+        result = _rule_based_clean("um  hello   world")
+        assert "  " not in result
+
+    def test_empty_string_returns_empty(self):
+        assert _rule_based_clean("") == ""
+
+    def test_preserves_meaningful_words(self):
+        result = _rule_based_clean("I need to go to the store")
+        assert "store" in result
+
+
+class TestTextCleanerNoneBackend:
+    def test_uses_rule_based(self):
+        cleaner = TextCleaner(backend="none")
+        result = cleaner.clean("um hello uh world")
+        assert "um" not in result.lower()
+        assert "uh" not in result.lower()
+        assert "world" in result.lower()
+
+    def test_blank_text_returned_unchanged(self):
+        cleaner = TextCleaner(backend="none")
+        assert cleaner.clean("") == ""
+        assert cleaner.clean("   ") == "   "
+
+
+class TestTextCleanerOllamaBackend:
+    def test_returns_llm_response(self):
+        cleaner = TextCleaner(backend="ollama")
+        response_body = json.dumps({"response": "I need to go to the store."}).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = cleaner._clean_ollama("um I need to go to the store")
+
+        assert result == "I need to go to the store."
+
+    def test_falls_back_to_rule_based_on_error(self):
+        cleaner = TextCleaner(backend="ollama")
+
+        with patch.object(cleaner, "_clean_ollama", side_effect=Exception("refused")):
+            result = cleaner.clean("um this is a test")
+
+        assert "um" not in result.lower()
+        assert "test" in result.lower()
+
+
+class TestTextCleanerGroqBackend:
+    def test_raises_without_api_key(self):
+        cleaner = TextCleaner(backend="groq", groq_api_key="")
+        with pytest.raises(ValueError, match="API key"):
+            cleaner._clean_groq("some text")
+
+    def test_returns_llm_response(self):
+        cleaner = TextCleaner(backend="groq", groq_api_key="test-key")
+        response_body = json.dumps(
+            {"choices": [{"message": {"content": "Cleaned text."}}]}
+        ).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_body
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = cleaner._clean_groq("um some text uh here")
+
+        assert result == "Cleaned text."
+
+    def test_falls_back_to_rule_based_on_error(self):
+        cleaner = TextCleaner(backend="groq", groq_api_key="test-key")
+
+        with patch.object(cleaner, "_clean_groq", side_effect=Exception("500")):
+            result = cleaner.clean("um this is a test")
+
+        assert "um" not in result.lower()
+        assert "test" in result.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,75 @@
+"""Tests for rawspeak.config — Config and load_config."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from rawspeak.config import Config, load_config, write_default_config
+
+
+class TestConfigDefaults:
+    def test_default_hotkey(self):
+        assert Config().hotkey == "<ctrl>+<alt>+<space>"
+
+    def test_default_sample_rate(self):
+        assert Config().sample_rate == 16000
+
+    def test_default_whisper_model(self):
+        assert Config().whisper_model == "openai/whisper-base"
+
+    def test_default_cleanup_backend(self):
+        assert Config().cleanup_backend == "ollama"
+
+
+class TestLoadConfig:
+    def test_returns_defaults_when_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", tmp_path / "nonexistent.toml")
+        config = load_config()
+        assert isinstance(config, Config)
+        assert config.sample_rate == 16000
+
+    def test_env_variable_sets_groq_api_key(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "env-key-123")
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", tmp_path / "nonexistent.toml")
+        config = load_config()
+        assert config.groq_api_key == "env-key-123"
+
+    def test_loads_values_from_toml_file(self, tmp_path, monkeypatch):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('whisper_model = "openai/whisper-tiny"\nsample_rate = 8000\n')
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", cfg_file)
+        config = load_config()
+        assert config.whisper_model == "openai/whisper-tiny"
+        assert config.sample_rate == 8000
+
+    def test_ignores_unknown_keys_in_toml(self, tmp_path, monkeypatch):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('nonexistent_key = "value"\n')
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", cfg_file)
+        config = load_config()  # should not raise
+        assert isinstance(config, Config)
+
+    def test_returns_defaults_on_malformed_toml(self, tmp_path, monkeypatch):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_bytes(b"\xff\xfe invalid toml !!!")
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", cfg_file)
+        config = load_config()
+        assert config.sample_rate == 16000
+
+
+class TestWriteDefaultConfig:
+    def test_creates_file_if_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("rawspeak.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", tmp_path / "config.toml")
+        write_default_config()
+        assert (tmp_path / "config.toml").exists()
+
+    def test_does_not_overwrite_existing_file(self, tmp_path, monkeypatch):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text("existing = true\n")
+        monkeypatch.setattr("rawspeak.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("rawspeak.config.CONFIG_FILE", cfg_file)
+        write_default_config()
+        assert cfg_file.read_text() == "existing = true\n"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,107 @@
+"""Tests for rawspeak.launcher — install / uninstall helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rawspeak.launcher import (
+    _PLIST_LABEL,
+    _rawspeak_executable,
+    install,
+    uninstall,
+)
+
+
+class TestRawspeakExecutable:
+    def test_returns_venv_bin_when_present(self, tmp_path):
+        fake_exe = tmp_path / "rawspeak"
+        fake_exe.touch()
+        with patch("rawspeak.launcher.sys") as mock_sys:
+            mock_sys.executable = str(tmp_path / "python")
+            mock_sys.platform = "darwin"
+            result = _rawspeak_executable()
+        assert result == str(fake_exe)
+
+    def test_falls_back_to_which(self, tmp_path):
+        # No rawspeak next to interpreter → fall back to shutil.which
+        with (
+            patch("rawspeak.launcher.sys") as mock_sys,
+            patch(
+                "rawspeak.launcher.shutil.which", return_value="/usr/local/bin/rawspeak"
+            ),
+        ):
+            mock_sys.executable = str(tmp_path / "python")
+            result = _rawspeak_executable()
+        assert result == "/usr/local/bin/rawspeak"
+
+    def test_raises_when_not_found(self, tmp_path):
+        with (
+            patch("rawspeak.launcher.sys") as mock_sys,
+            patch("rawspeak.launcher.shutil.which", return_value=None),
+        ):
+            mock_sys.executable = str(tmp_path / "python")
+            with pytest.raises(FileNotFoundError):
+                _rawspeak_executable()
+
+
+class TestInstall:
+    def test_writes_plist_and_calls_launchctl(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / f"{_PLIST_LABEL}.plist"
+        log_path = tmp_path / "rawspeak.log"
+
+        monkeypatch.setattr("rawspeak.launcher._PLIST_PATH", plist_path)
+        monkeypatch.setattr("rawspeak.launcher.sys.platform", "darwin")
+
+        mock_run = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+        with (
+            patch(
+                "rawspeak.launcher._rawspeak_executable", return_value="/bin/rawspeak"
+            ),
+            patch("rawspeak.launcher.subprocess.run", mock_run),
+            patch("rawspeak.launcher.Path.home", return_value=tmp_path),
+        ):
+            install()
+
+        assert plist_path.exists()
+        content = plist_path.read_text()
+        assert "/bin/rawspeak" in content
+        assert _PLIST_LABEL in content
+
+    def test_exits_on_non_macos(self, monkeypatch):
+        monkeypatch.setattr("rawspeak.launcher.sys.platform", "linux")
+        with pytest.raises(SystemExit):
+            install()
+
+
+class TestUninstall:
+    def test_removes_plist_and_calls_launchctl(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / f"{_PLIST_LABEL}.plist"
+        plist_path.write_text("<plist/>")
+
+        monkeypatch.setattr("rawspeak.launcher._PLIST_PATH", plist_path)
+        monkeypatch.setattr("rawspeak.launcher.sys.platform", "darwin")
+
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        with patch("rawspeak.launcher.subprocess.run", mock_run):
+            uninstall()
+
+        assert not plist_path.exists()
+        mock_run.assert_called_once()
+
+    def test_noop_when_not_installed(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / f"{_PLIST_LABEL}.plist"
+        monkeypatch.setattr("rawspeak.launcher._PLIST_PATH", plist_path)
+        monkeypatch.setattr("rawspeak.launcher.sys.platform", "darwin")
+
+        uninstall()  # should not raise
+
+        captured = capsys.readouterr()
+        assert "not installed" in captured.out
+
+    def test_exits_on_non_macos(self, monkeypatch):
+        monkeypatch.setattr("rawspeak.launcher.sys.platform", "linux")
+        with pytest.raises(SystemExit):
+            uninstall()

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -1,0 +1,62 @@
+"""Tests for rawspeak.paste — Paster."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rawspeak.paste import Paster
+
+
+class TestPasterPaste:
+    def test_does_nothing_for_empty_text(self):
+        paster = Paster()
+        with patch.object(paster, "_set_clipboard") as mock_clip, \
+             patch.object(paster, "_send_paste") as mock_paste:
+            paster.paste("")
+            paster.paste("   ")
+        mock_clip.assert_not_called()
+        mock_paste.assert_not_called()
+
+    def test_sets_clipboard_then_pastes(self):
+        paster = Paster(paste_delay=0)
+        with patch.object(paster, "_set_clipboard") as mock_clip, \
+             patch.object(paster, "_send_paste") as mock_paste:
+            paster.paste("hello world")
+        mock_clip.assert_called_once_with("hello world")
+        mock_paste.assert_called_once()
+
+    def test_paste_delay_is_respected(self):
+        import time
+        paster = Paster(paste_delay=0.05)
+        with patch.object(paster, "_set_clipboard"), \
+             patch.object(paster, "_send_paste"):
+            start = time.monotonic()
+            paster.paste("hi")
+            elapsed = time.monotonic() - start
+        assert elapsed >= 0.04
+
+
+class TestPasterHelpers:
+    def test_set_clipboard_calls_pyperclip(self):
+        paster = Paster()
+        with patch("pyperclip.copy") as mock_copy:
+            paster._set_clipboard("test text")
+        mock_copy.assert_called_once_with("test text")
+
+    def test_send_paste_calls_pyautogui(self):
+        paster = Paster()
+        mock_pyautogui = MagicMock()
+        with patch.dict("sys.modules", {"pyautogui": mock_pyautogui}):
+            with patch("sys.platform", "linux"):
+                paster._send_paste()
+        mock_pyautogui.hotkey.assert_called_once_with("ctrl", "v")
+
+    def test_send_paste_uses_command_v_on_macos(self):
+        paster = Paster()
+        mock_pyautogui = MagicMock()
+        with patch.dict("sys.modules", {"pyautogui": mock_pyautogui}):
+            with patch("sys.platform", "darwin"):
+                paster._send_paste()
+        mock_pyautogui.hotkey.assert_called_once_with("command", "v")

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,122 @@
+"""Tests for rawspeak.transcriber — Transcriber and _resample."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from rawspeak.transcriber import Transcriber, _resample, _is_hallucination
+
+
+class TestTranscriber:
+    def test_empty_audio_returns_empty_string(self):
+        t = Transcriber()
+        assert t.transcribe(np.array([], dtype=np.float32)) == ""
+
+    def test_calls_pipeline_with_correct_inputs(self):
+        t = Transcriber(model_name="openai/whisper-base")
+        mock_pipeline = MagicMock(return_value={"text": " hello world "})
+        t._pipeline = mock_pipeline
+
+        audio = np.zeros(16000, dtype=np.float32)
+        result = t.transcribe(audio, sample_rate=16000)
+
+        assert result == "hello world"
+        call_args = mock_pipeline.call_args
+        assert call_args[0][0]["sampling_rate"] == 16000
+        assert len(call_args[0][0]["array"]) == 16000
+
+    def test_passes_language_and_task_in_generate_kwargs(self):
+        t = Transcriber(language="fr")
+        t._pipeline = MagicMock(return_value={"text": "bonjour"})
+
+        t.transcribe(np.zeros(16000, dtype=np.float32))
+
+        _, kwargs = t._pipeline.call_args
+        assert kwargs["generate_kwargs"]["language"] == "fr"
+        assert kwargs["generate_kwargs"]["task"] == "transcribe"
+
+    def test_hallucinated_output_returns_empty_string(self):
+        t = Transcriber()
+        # Simulate the "asa, asa, asa, ..." hallucination pattern
+        hallucination = ", ".join(["asa"] * 50)
+        t._pipeline = MagicMock(return_value={"text": hallucination})
+
+        result = t.transcribe(np.zeros(16000, dtype=np.float32))
+
+        assert result == ""
+
+    def test_strips_whitespace_from_pipeline_output(self):
+        t = Transcriber()
+        t._pipeline = MagicMock(return_value={"text": "   padded text   "})
+        result = t.transcribe(np.zeros(16000, dtype=np.float32))
+        assert result == "padded text"
+
+    def test_handles_missing_text_key(self):
+        t = Transcriber()
+        t._pipeline = MagicMock(return_value={"chunks": []})
+        result = t.transcribe(np.zeros(16000, dtype=np.float32))
+        assert result == ""
+
+    def test_resamples_when_sample_rate_differs(self):
+        t = Transcriber()
+        received = {}
+
+        def capture_pipeline(inputs, **kwargs):
+            received.update(inputs)
+            return {"text": "ok"}
+
+        t._pipeline = capture_pipeline
+        # 8 kHz audio → should be upsampled to 16 kHz before passing to pipeline
+        audio_8k = np.ones(8000, dtype=np.float32)
+        t.transcribe(audio_8k, sample_rate=8000)
+
+        assert received["sampling_rate"] == 16000
+        assert len(received["array"]) == 16000
+
+
+class TestResample:
+    def test_noop_when_rates_match(self):
+        audio = np.arange(100, dtype=np.float32)
+        result = _resample(audio, 16000, 16000)
+        np.testing.assert_array_equal(result, audio)
+
+    def test_upsample_doubles_length(self):
+        audio = np.ones(8000, dtype=np.float32)
+        result = _resample(audio, 8000, 16000)
+        assert len(result) == 16000
+
+    def test_downsample_halves_length(self):
+        audio = np.ones(16000, dtype=np.float32)
+        result = _resample(audio, 16000, 8000)
+        assert len(result) == 8000
+
+    def test_output_dtype_is_float32(self):
+        audio = np.ones(4000, dtype=np.float32)
+        result = _resample(audio, 8000, 16000)
+        assert result.dtype == np.float32
+
+
+class TestIsHallucination:
+    def test_asa_repetition_detected(self):
+        text = ", ".join(["asa"] * 50)
+        assert _is_hallucination(text) is True
+
+    def test_normal_sentence_not_hallucination(self):
+        assert _is_hallucination("I need to go to the store today") is False
+
+    def test_short_text_not_hallucination(self):
+        # Fewer than 8 words — never flagged regardless of repetition.
+        assert _is_hallucination("asa asa asa asa") is False
+
+    def test_slightly_repetitive_normal_not_flagged(self):
+        # "the" appears 3/12 times = 25 % — below the 50 % threshold.
+        text = "the cat sat on the mat and the dog ran to the park"
+        assert _is_hallucination(text) is False
+
+    def test_majority_single_token_flagged(self):
+        # Word "blah" makes up 9/11 tokens — above threshold.
+        text = "blah blah blah blah blah blah blah blah blah is fine"
+        assert _is_hallucination(text) is True


### PR DESCRIPTION
## Summary
- add core RawSpeak runtime pipeline: hotkey capture, recording, transcription, cleanup, and paste flow
- add tray state handling and macOS launcher install/uninstall support
- add baseline unit tests and README documentation for setup, usage, and development workflow

## Test plan
- [ ] Run `pytest`
- [ ] Validate package metadata and dependencies in `pyproject.toml`
- [ ] Confirm branch includes issue reference `#1` in commit messages

## Related Issues
- #1