### PR TITLE
ci: build and release macOS DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Build & Release macOS DMG
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  build-and-release:
+    needs: test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(python -c "from rawspeak import __version__; print(__version__)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build .app with PyInstaller
+        if: steps.check.outputs.exists == 'false'
+        run: pyinstaller rawspeak.spec --noconfirm
+
+      - name: Install create-dmg
+        if: steps.check.outputs.exists == 'false'
+        run: brew install create-dmg
+
+      - name: Build DMG
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist/dmg
+          cp -R dist/RawSpeak.app dist/dmg/
+          create-dmg \
+            --volname "RawSpeak" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --icon-size 100 \
+            --icon "RawSpeak.app" 200 190 \
+            --hide-extension "RawSpeak.app" \
+            --app-drop-link 600 185 \
+            "dist/RawSpeak-${VERSION}.dmg" \
+            "dist/dmg/" \
+            || true
+          ls -lh dist/*.dmg
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          DMG=$(ls dist/*.dmg | head -1)
+          gh release create "$TAG" "$DMG" \
+            --title "RawSpeak $VERSION" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.venv/
+.DS_Store
+.env
+.env.local
+rawspeak.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-mock>=3.10",
+    "pyinstaller>=6.0",
 ]
 
 [project.scripts]

--- a/rawspeak.spec
+++ b/rawspeak.spec
@@ -1,0 +1,81 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for building RawSpeak as a macOS .app bundle."""
+
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+a = Analysis(
+    ["rawspeak/main.py"],
+    pathex=["."],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        "pynput",
+        "pynput.keyboard",
+        "pynput.keyboard._darwin",
+        "pynput.mouse",
+        "pynput.mouse._darwin",
+        "sounddevice",
+        "numpy",
+        "torch",
+        "transformers",
+        "transformers.models.whisper",
+        "pyperclip",
+        "pyautogui",
+        "pystray",
+        "pystray._darwin",
+        "PIL",
+        "PIL.Image",
+        "PIL.ImageDraw",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=["tkinter", "matplotlib", "IPython", "notebook", "scipy"],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="RawSpeak",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    target_arch=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="RawSpeak",
+)
+
+app = BUNDLE(
+    coll,
+    name="RawSpeak.app",
+    bundle_identifier="com.rawspeak.app",
+    info_plist={
+        "CFBundleShortVersionString": "0.1.0",
+        "CFBundleName": "RawSpeak",
+        "CFBundleDisplayName": "RawSpeak",
+        "NSMicrophoneUsageDescription": "RawSpeak needs microphone access to record your voice for transcription.",
+        "NSAppleEventsUsageDescription": "RawSpeak needs accessibility access to paste transcribed text.",
+        "LSUIElement": True,
+    },
+)

--- a/rawspeak/config.py
+++ b/rawspeak/config.py
@@ -27,12 +27,15 @@ DEFAULT_CONFIG_TOML = """\
 # rawspeak configuration
 # Edit this file to customise rawspeak behaviour.
 
-# Global hotkey to toggle recording.
+# Global hotkey to toggle recording (pynput format).
 # Examples: "<ctrl>+<alt>+<space>", "<ctrl>+<shift>+r"
+# Function keys work well as single-key triggers: "<f5>", "<f6>", etc.
+# Note: Fn+<key> is not a distinct event on macOS — use a function key directly.
 hotkey = "<ctrl>+<alt>+<space>"
 
 # Optional mouse button that also toggles recording.
 # Values: "middle" (scroll-wheel click), "x1", "x2", or "" to disable.
+# "middle" = clicking the scroll wheel, which works as a convenient toggle.
 mouse_button = "middle"
 
 # Audio capture settings.

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION=$(python -c "from rawspeak import __version__; print(__version__)")
+APP_NAME="RawSpeak"
+DMG_NAME="${APP_NAME}-${VERSION}.dmg"
+
+echo "==> Building ${APP_NAME} v${VERSION}"
+
+echo "--- Running PyInstaller ---"
+pyinstaller rawspeak.spec --noconfirm
+
+echo "--- Preparing DMG staging ---"
+mkdir -p dist/dmg
+rm -rf dist/dmg/*
+cp -R "dist/${APP_NAME}.app" dist/dmg/
+
+echo "--- Creating DMG ---"
+test -f "dist/${DMG_NAME}" && rm "dist/${DMG_NAME}"
+
+create-dmg \
+  --volname "${APP_NAME}" \
+  --window-pos 200 120 \
+  --window-size 800 400 \
+  --icon-size 100 \
+  --icon "${APP_NAME}.app" 200 190 \
+  --hide-extension "${APP_NAME}.app" \
+  --app-drop-link 600 185 \
+  "dist/${DMG_NAME}" \
+  "dist/dmg/" \
+  || true
+
+if [ -f "dist/${DMG_NAME}" ]; then
+  echo "==> DMG created: dist/${DMG_NAME}"
+else
+  ls dist/*.dmg 2>/dev/null && echo "==> DMG created (name may vary from create-dmg)" \
+    || { echo "ERROR: DMG creation failed"; exit 1; }
+fi


### PR DESCRIPTION
## Summary
- add macOS packaging via PyInstaller (`rawspeak.spec`) and local DMG builder (`scripts/build_dmg.sh`)
- add GitHub Actions workflow to test and publish a DMG release on pushes to `main`
- document function-key hotkey options in default config

## Test plan
- [x] `pytest`

## Notes
- This is MVP packaging (no Apple signing/notarization yet).

Made with [Cursor](https://cursor.com)