### PR TITLE
docs: add macos gatekeeper and permissions setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ rawspeak
 
 A tray icon appears. Press **Ctrl + Alt + Space** to toggle recording.
 
+### 5. macOS first launch (Gatekeeper + permissions)
+
+If you install the DMG build, macOS may show:
+"Apple could not verify 'RawSpeak' is free of malware..."
+
+This is expected for unsigned/not-notarized MVP builds.
+
+1. Drag `RawSpeak.app` to `Applications`.
+2. In Finder, open `Applications`, right-click `RawSpeak`, then click `Open`.
+3. If still blocked, go to `System Settings -> Privacy & Security` and click `Open Anyway` for RawSpeak.
+
+After launch, grant required permissions:
+
+- `System Settings -> Privacy & Security -> Microphone` -> enable `RawSpeak`
+- `System Settings -> Privacy & Security -> Accessibility` -> enable `RawSpeak`
+- `System Settings -> Privacy & Security -> Input Monitoring` -> enable `RawSpeak`
+
+Without these permissions, hotkeys, recording, or paste automation may fail.
+
 ---
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rawspeak"
-version = "0.1.1"
+version = "0.1.2"
 description = "Local voice-to-text desktop tool — privacy-first Whisper + LLM dictation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/rawspeak.spec
+++ b/rawspeak.spec
@@ -75,7 +75,7 @@ app = BUNDLE(
     bundle_identifier="com.rawspeak.app",
     icon=APP_ICON,
     info_plist={
-        "CFBundleShortVersionString": "0.1.1",
+        "CFBundleShortVersionString": "0.1.2",
         "CFBundleName": "RawSpeak",
         "CFBundleDisplayName": "RawSpeak",
         "NSMicrophoneUsageDescription": "RawSpeak needs microphone access to record your voice for transcription.",

--- a/rawspeak/__init__.py
+++ b/rawspeak/__init__.py
@@ -1,3 +1,3 @@
 """rawspeak - Local voice-to-text desktop tool."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Document the first-launch Gatekeeper bypass steps and required macOS permissions for microphone, input monitoring, and accessibility.