### PR TITLE
feat: add Electron UI with history and macOS hotkey reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .env.local
 rawspeak.egg-info/
 assets/*.iconset/
+electron/node_modules/

--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ pip install -e ".[dev]"
 pytest
 ```
 
+### Electron UI (experimental)
+
+This repo now includes a minimal Electron interface in `electron/`.
+It starts the Python backend in headless mode and shows processed speech history.
+
+```bash
+cd electron
+npm install
+npm start
+```
+
+Notes:
+- On macOS, if running Python 3.13 locally, the app uses a Quartz-based hotkey listener.
+- The Electron window reads `~/.config/rawspeak/history.jsonl` and updates live.
+
 ---
 
 ## Roadmap (post-v1)

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,218 @@
+const { app, BrowserWindow, ipcMain, Tray, nativeImage, clipboard } = require("electron");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { spawn } = require("child_process");
+
+const HISTORY_PATH = path.join(os.homedir(), ".config", "rawspeak", "history.jsonl");
+let backend = null;
+let historyWatcher = null;
+let statusTray = null;
+let idleHideTimer = null;
+
+app.setName("RawSpeak");
+
+function createCircleTrayImage(hexColor) {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+      <circle cx="10" cy="10" r="7" fill="${hexColor}" />
+    </svg>
+  `;
+  const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+  return nativeImage.createFromDataURL(dataUrl);
+}
+
+function ensureTray() {
+  if (!statusTray) {
+    statusTray = new Tray(nativeImage.createEmpty());
+    statusTray.setToolTip("RawSpeak");
+  }
+}
+
+function hideTray() {
+  if (idleHideTimer) {
+    clearTimeout(idleHideTimer);
+    idleHideTimer = null;
+  }
+  if (statusTray) {
+    statusTray.destroy();
+    statusTray = null;
+  }
+}
+
+function setTrayState(state) {
+  if (idleHideTimer) {
+    clearTimeout(idleHideTimer);
+    idleHideTimer = null;
+  }
+
+  // Keep tray indicator visible while actively recording/processing.
+  // For idle/done, show blue briefly then hide.
+  const palette = {
+    listening: { color: "#ef4444", tooltip: "RawSpeak — listening", symbol: "🔴" },
+    processing: { color: "#f59e0b", tooltip: "RawSpeak — processing", symbol: "🟠" },
+    idle: { color: "#3b82f6", tooltip: "RawSpeak — idle", symbol: "🔵" },
+  };
+  const info = palette[state] || palette.idle;
+
+  ensureTray();
+  statusTray.setImage(createCircleTrayImage(info.color));
+  statusTray.setTitle(info.symbol);
+  statusTray.setToolTip(info.tooltip);
+
+  if (state === "idle") {
+    idleHideTimer = setTimeout(() => {
+      hideTray();
+    }, 1200);
+  }
+}
+
+function updateStatusFromLogLine(line) {
+  const msg = line.toLowerCase();
+  if (msg.includes("recording started")) {
+    setTrayState("listening");
+    return;
+  }
+  if (msg.includes("recording stopped") || msg.includes("processing audio")) {
+    setTrayState("processing");
+    return;
+  }
+  if (
+    msg.includes("done!") ||
+    msg.includes("empty transcription") ||
+    msg.includes("recording too short") ||
+    msg.includes("error in pipeline")
+  ) {
+    setTrayState("idle");
+  }
+}
+
+function parseHistory(limit = 300) {
+  if (!fs.existsSync(HISTORY_PATH)) return [];
+  const lines = fs
+    .readFileSync(HISTORY_PATH, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const entries = [];
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (!obj.text || !String(obj.text).trim()) continue;
+      entries.push({
+        timestamp: obj.timestamp || "--",
+        text: String(obj.text),
+      });
+    } catch {
+      // ignore malformed line
+    }
+  }
+  return entries.slice(-limit).reverse();
+}
+
+function spawnBackend() {
+  if (backend) return;
+  const repoRoot = path.resolve(__dirname, "..");
+  const venvPython = path.join(repoRoot, ".venv", "bin", "python");
+  const pythonBin = fs.existsSync(venvPython) ? venvPython : "python3";
+
+  backend = spawn(pythonBin, ["-m", "rawspeak.main", "run-headless"], {
+    cwd: repoRoot,
+    env: { ...process.env, PYTHONUNBUFFERED: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const handleBackendOutput = (chunk, isError = false) => {
+    const text = chunk.toString();
+    for (const line of text.split("\n")) {
+      const msg = line.trim();
+      if (!msg) continue;
+      if (isError) {
+        console.error(`[rawspeak:error] ${msg}`);
+      } else {
+        console.log(`[rawspeak] ${msg}`);
+      }
+      updateStatusFromLogLine(msg);
+    }
+  };
+
+  // Python logging defaults to stderr, so parse both streams.
+  backend.stdout.on("data", (chunk) => handleBackendOutput(chunk, false));
+  backend.stderr.on("data", (chunk) => handleBackendOutput(chunk, true));
+
+  backend.on("exit", (code) => {
+    console.log(`[rawspeak] backend exited with code ${code}`);
+    backend = null;
+  });
+}
+
+function stopBackend() {
+  if (!backend) return;
+  backend.kill();
+  backend = null;
+  hideTray();
+}
+
+function watchHistory(win) {
+  if (historyWatcher) historyWatcher.close();
+  const historyDir = path.dirname(HISTORY_PATH);
+  fs.mkdirSync(historyDir, { recursive: true });
+
+  historyWatcher = fs.watch(historyDir, { persistent: false }, (_evt, filename) => {
+    if (filename && filename !== path.basename(HISTORY_PATH)) return;
+    if (!win || win.isDestroyed()) return;
+    win.webContents.send("history-updated", parseHistory());
+  });
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 980,
+    height: 640,
+    minWidth: 720,
+    minHeight: 420,
+    title: "RawSpeak",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  win.loadFile(path.join(__dirname, "renderer", "index.html"));
+  watchHistory(win);
+  return win;
+}
+
+ipcMain.handle("history-list", async () => parseHistory());
+ipcMain.handle("history-copy", async (_event, text) => {
+  clipboard.writeText(String(text || ""));
+  return true;
+});
+
+app.whenReady().then(() => {
+  const logoPath = path.resolve(__dirname, "..", "assets", "rawspeak_logo.png");
+  if (process.platform === "darwin" && app.dock && fs.existsSync(logoPath)) {
+    app.dock.setIcon(logoPath);
+  }
+
+  spawnBackend();
+  const win = createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+
+  win.on("closed", () => {
+    if (historyWatcher) {
+      historyWatcher.close();
+      historyWatcher = null;
+    }
+  });
+});
+
+app.on("window-all-closed", () => {
+  stopBackend();
+  if (process.platform !== "darwin") app.quit();
+});

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,0 +1,801 @@
+{
+  "name": "rawspeak-electron",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rawspeak-electron",
+      "version": "0.1.0",
+      "devDependencies": {
+        "electron": "^37.2.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "37.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rawspeak-electron",
+  "productName": "RawSpeak",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Electron UI for RawSpeak history",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^37.2.0"
+  }
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,11 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("rawspeak", {
+  listHistory: () => ipcRenderer.invoke("history-list"),
+  copyText: (text) => ipcRenderer.invoke("history-copy", text),
+  onHistoryUpdated: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on("history-updated", handler);
+    return () => ipcRenderer.removeListener("history-updated", handler);
+  },
+});

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RawSpeak</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="top card">
+        <div>
+          <h1>RawSpeak</h1>
+          <p>Processed speech history</p>
+        </div>
+        <div class="badge">Live</div>
+      </header>
+
+      <section class="hint card">
+        <strong>Hotkey:</strong> set `hotkey = "&lt;f5&gt;"` in your config if desired.
+      </section>
+
+      <section class="stats">
+        <article class="stat card">
+          <p class="label">Today</p>
+          <p id="today-count" class="value">0</p>
+        </article>
+        <article class="stat card">
+          <p class="label">Total shown</p>
+          <p id="total-count" class="value">0</p>
+        </article>
+      </section>
+
+      <section class="list-wrap card">
+        <table id="history-table">
+          <thead>
+            <tr>
+              <th class="time-col">Time</th>
+              <th>Text</th>
+              <th class="actions-col"></th>
+            </tr>
+          </thead>
+          <tbody id="history-body"></tbody>
+        </table>
+        <div id="empty" class="empty">No processed speech yet.</div>
+      </section>
+      <div id="toast" class="toast">Copied</div>
+    </main>
+
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/electron/renderer/renderer.js
+++ b/electron/renderer/renderer.js
@@ -1,0 +1,77 @@
+let toastTimer = null;
+
+async function copyToClipboard(text) {
+  await window.rawspeak.copyText(text || "");
+  showToast("Copied");
+}
+
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  toast.textContent = message;
+  toast.classList.add("show");
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toast.classList.remove("show"), 900);
+}
+
+function renderRows(entries) {
+  const body = document.getElementById("history-body");
+  const empty = document.getElementById("empty");
+  const totalCount = document.getElementById("total-count");
+  const todayCount = document.getElementById("today-count");
+  body.innerHTML = "";
+
+  const list = entries || [];
+  totalCount.textContent = String(list.length);
+  todayCount.textContent = String(list.length);
+
+  if (list.length === 0) {
+    empty.style.display = "block";
+    return;
+  }
+
+  empty.style.display = "none";
+  for (const entry of list) {
+    const tr = document.createElement("tr");
+    const tdTime = document.createElement("td");
+    const tdText = document.createElement("td");
+    const tdActions = document.createElement("td");
+    tdTime.textContent = entry.timestamp || "--";
+    tdText.textContent = entry.text || "";
+    tdTime.className = "time-cell";
+    tdText.className = "text-cell";
+
+    const wrap = document.createElement("div");
+    wrap.className = "row-actions";
+    const copyBtn = document.createElement("button");
+    copyBtn.className = "icon-btn";
+    copyBtn.type = "button";
+    copyBtn.title = "Copy";
+    copyBtn.ariaLabel = "Copy";
+    copyBtn.textContent = "⧉";
+    copyBtn.addEventListener("click", async (event) => {
+      event.stopPropagation();
+      await copyToClipboard(entry.text || "");
+    });
+    wrap.appendChild(copyBtn);
+    tdActions.appendChild(wrap);
+
+    tr.addEventListener("click", async () => {
+      await copyToClipboard(entry.text || "");
+    });
+
+    tr.appendChild(tdTime);
+    tr.appendChild(tdText);
+    tr.appendChild(tdActions);
+    body.appendChild(tr);
+  }
+}
+
+async function boot() {
+  const entries = await window.rawspeak.listHistory();
+  renderRows(entries);
+  window.rawspeak.onHistoryUpdated((nextEntries) => {
+    renderRows(nextEntries);
+  });
+}
+
+boot();

--- a/electron/renderer/styles.css
+++ b/electron/renderer/styles.css
@@ -1,0 +1,183 @@
+:root {
+  color-scheme: light dark;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top right, #dbeafe, #f8fafc 40%, #f3f4f6);
+  color: #111827;
+}
+
+.app {
+  padding: 20px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.card {
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  box-shadow: 0 10px 25px rgba(17, 24, 39, 0.06);
+}
+
+.top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 18px;
+}
+
+.top h1 {
+  margin: 0;
+  font-size: 30px;
+  letter-spacing: -0.02em;
+}
+
+.top p {
+  margin: 4px 0 0;
+  color: #6b7280;
+}
+
+.badge {
+  font-size: 12px;
+  font-weight: 700;
+  color: #0f766e;
+  background: #ccfbf1;
+  border: 1px solid #99f6e4;
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.hint {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #1f2937;
+}
+
+.stats {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.stat {
+  padding: 12px 14px;
+}
+
+.stat .label {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.stat .value {
+  margin: 6px 0 0;
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.list-wrap {
+  margin-top: 14px;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead th {
+  text-align: left;
+  font-size: 13px;
+  color: #6b7280;
+  font-weight: 600;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+tbody td {
+  padding: 10px 12px;
+  border-top: 1px solid #f3f4f6;
+  vertical-align: top;
+}
+
+tbody tr:hover td {
+  background: #f3f4f6;
+}
+
+tbody tr {
+  cursor: copy;
+}
+
+.time-col {
+  width: 120px;
+}
+
+.actions-col {
+  width: 64px;
+}
+
+.text-cell {
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.35;
+}
+
+.time-cell {
+  white-space: normal;
+  line-height: 1.25;
+}
+
+.row-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.icon-btn {
+  border: 0;
+  background: transparent;
+  color: #6b7280;
+  font-size: 16px;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.empty {
+  padding: 22px 12px;
+  color: #9ca3af;
+}
+
+.toast {
+  position: fixed;
+  right: 22px;
+  bottom: 18px;
+  background: #111827;
+  color: #f9fafb;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  pointer-events: none;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rawspeak"
-version = "0.1.4"
+version = "0.1.5"
 description = "Local voice-to-text desktop tool — privacy-first Whisper + LLM dictation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/rawspeak.spec
+++ b/rawspeak.spec
@@ -75,7 +75,7 @@ app = BUNDLE(
     bundle_identifier="com.rawspeak.app",
     icon=APP_ICON,
     info_plist={
-        "CFBundleShortVersionString": "0.1.4",
+        "CFBundleShortVersionString": "0.1.5",
         "CFBundleName": "RawSpeak",
         "CFBundleDisplayName": "RawSpeak",
         "NSMicrophoneUsageDescription": "RawSpeak needs microphone access to record your voice for transcription.",

--- a/rawspeak/__init__.py
+++ b/rawspeak/__init__.py
@@ -1,3 +1,3 @@
 """rawspeak - Local voice-to-text desktop tool."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/rawspeak/history.py
+++ b/rawspeak/history.py
@@ -1,0 +1,63 @@
+"""Persistent storage for processed speech entries."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .config import CONFIG_DIR
+
+HISTORY_FILE = CONFIG_DIR / "history.jsonl"
+
+
+@dataclass
+class HistoryEntry:
+    timestamp: str
+    text: str
+
+
+class HistoryStore:
+    """Store and retrieve processed speech history as JSON lines."""
+
+    def __init__(self, path: Path = HISTORY_FILE) -> None:
+        self.path = path
+
+    def append(self, text: str) -> HistoryEntry:
+        entry = HistoryEntry(
+            timestamp=datetime.now().strftime("%I:%M %p").lstrip("0"),
+            text=text.strip(),
+        )
+        if not entry.text:
+            return entry
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry.__dict__, ensure_ascii=False) + "\n")
+        return entry
+
+    def list_recent(self, limit: int = 300) -> List[HistoryEntry]:
+        if not self.path.exists():
+            return []
+
+        entries: List[HistoryEntry] = []
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                    text = str(payload.get("text", "")).strip()
+                    timestamp = str(payload.get("timestamp", "")).strip()
+                    if not text:
+                        continue
+                    entries.append(HistoryEntry(timestamp=timestamp, text=text))
+                except Exception:
+                    continue
+
+        if limit <= 0:
+            return entries
+        return entries[-limit:]

--- a/rawspeak/hotkey.py
+++ b/rawspeak/hotkey.py
@@ -1,9 +1,11 @@
-"""Global hotkey listener using *pynput*."""
+"""Global hotkey listener using Quartz on macOS and pynput elsewhere."""
 
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional
+import sys
+import threading
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,7 @@ class HotkeyListener:
         self.mouse_button = mouse_button
         self._listener = None
         self._mouse_listener = None
+        self._mac_listener = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -43,17 +46,22 @@ class HotkeyListener:
 
     def start(self) -> None:
         """Start listening for the hotkey (and optional mouse button) in daemon threads."""
-        from pynput import keyboard
-
         def _safe_activate() -> None:
             try:
                 self.on_activate()
             except Exception:
                 logger.exception("Unhandled error in hotkey callback")
 
-        self._listener = keyboard.GlobalHotKeys({self.hotkey: _safe_activate})
-        self._listener.start()
-        logger.debug("Hotkey listener started for %r", self.hotkey)
+        if sys.platform == "darwin":
+            self._mac_listener = _MacHotkeyListener(self.hotkey, _safe_activate)
+            self._mac_listener.start()
+            logger.debug("macOS hotkey listener started for %r", self.hotkey)
+        else:
+            from pynput import keyboard
+
+            self._listener = keyboard.GlobalHotKeys({self.hotkey: _safe_activate})
+            self._listener.start()
+            logger.debug("Hotkey listener started for %r", self.hotkey)
 
         if self.mouse_button:
             self._start_mouse_listener(_safe_activate)
@@ -83,7 +91,143 @@ class HotkeyListener:
         if self._listener is not None:
             self._listener.stop()
             self._listener = None
+        if self._mac_listener is not None:
+            self._mac_listener.stop()
+            self._mac_listener = None
         if self._mouse_listener is not None:
             self._mouse_listener.stop()
             self._mouse_listener = None
         logger.debug("Hotkey listener stopped")
+
+
+class _MacHotkeyListener:
+    """Quartz-based global key listener for macOS."""
+
+    _KEYCODES = {
+        "space": 49,
+        "f1": 122,
+        "f2": 120,
+        "f3": 99,
+        "f4": 118,
+        "f5": 96,
+        "f6": 97,
+        "f7": 98,
+        "f8": 100,
+        "f9": 101,
+        "f10": 109,
+        "f11": 103,
+        "f12": 111,
+        "a": 0,
+        "b": 11,
+        "c": 8,
+        "d": 2,
+        "e": 14,
+        "f": 3,
+        "g": 5,
+        "h": 4,
+        "i": 34,
+        "j": 38,
+        "k": 40,
+        "l": 37,
+        "m": 46,
+        "n": 45,
+        "o": 31,
+        "p": 35,
+        "q": 12,
+        "r": 15,
+        "s": 1,
+        "t": 17,
+        "u": 32,
+        "v": 9,
+        "w": 13,
+        "x": 7,
+        "y": 16,
+        "z": 6,
+    }
+
+    def __init__(self, hotkey: str, on_activate: Callable[[], None]) -> None:
+        self.hotkey = hotkey
+        self.on_activate = on_activate
+        self._thread = None
+        self._run_loop = None
+        self._event_tap = None
+        self._callback = None
+        self._required_keycode, self._required_modifiers = self._parse_hotkey(hotkey)
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True, name="rawspeak-mac-hotkey")
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._run_loop is None:
+            return
+        import Quartz
+
+        Quartz.CFRunLoopStop(self._run_loop)
+        if self._event_tap is not None:
+            Quartz.CFMachPortInvalidate(self._event_tap)
+
+    @classmethod
+    def _parse_hotkey(cls, hotkey: str) -> tuple[int, int]:
+        import Quartz
+
+        modifier_map = {
+            "ctrl": Quartz.kCGEventFlagMaskControl,
+            "control": Quartz.kCGEventFlagMaskControl,
+            "alt": Quartz.kCGEventFlagMaskAlternate,
+            "option": Quartz.kCGEventFlagMaskAlternate,
+            "shift": Quartz.kCGEventFlagMaskShift,
+            "cmd": Quartz.kCGEventFlagMaskCommand,
+            "command": Quartz.kCGEventFlagMaskCommand,
+        }
+
+        required_modifiers = 0
+        required_keycode = None
+        tokens = [t.strip().lower().strip("<>") for t in hotkey.split("+") if t.strip()]
+        for token in tokens:
+            if token in modifier_map:
+                required_modifiers |= modifier_map[token]
+            elif token in cls._KEYCODES:
+                required_keycode = cls._KEYCODES[token]
+
+        if required_keycode is None:
+            raise ValueError(
+                f"Unsupported hotkey {hotkey!r}. Use keys like <space>, <f5>, or letters."
+            )
+        return required_keycode, required_modifiers
+
+    def _run(self) -> None:
+        import Quartz
+
+        def _callback(_proxy, event_type, event, _refcon):
+            if event_type != Quartz.kCGEventKeyDown:
+                return event
+
+            keycode = Quartz.CGEventGetIntegerValueField(event, Quartz.kCGKeyboardEventKeycode)
+            flags = Quartz.CGEventGetFlags(event)
+            if keycode == self._required_keycode and (flags & self._required_modifiers) == self._required_modifiers:
+                try:
+                    self.on_activate()
+                except Exception:
+                    logger.exception("Unhandled error in macOS hotkey callback")
+            return event
+
+        self._callback = _callback
+        event_mask = Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown)
+        self._event_tap = Quartz.CGEventTapCreate(
+            Quartz.kCGSessionEventTap,
+            Quartz.kCGHeadInsertEventTap,
+            Quartz.kCGEventTapOptionListenOnly,
+            event_mask,
+            self._callback,
+            None,
+        )
+        if self._event_tap is None:
+            logger.error("Failed to create macOS event tap for global hotkeys")
+            return
+
+        source = Quartz.CFMachPortCreateRunLoopSource(None, self._event_tap, 0)
+        self._run_loop = Quartz.CFRunLoopGetCurrent()
+        Quartz.CFRunLoopAddSource(self._run_loop, source, Quartz.kCFRunLoopCommonModes)
+        Quartz.CGEventTapEnable(self._event_tap, True)
+        Quartz.CFRunLoopRun()

--- a/rawspeak/main.py
+++ b/rawspeak/main.py
@@ -9,6 +9,7 @@ import threading
 from .audio import AudioRecorder
 from .cleaner import TextCleaner
 from .config import load_config, write_default_config
+from .history import HistoryStore
 from .hotkey import HotkeyListener
 from .paste import Paster
 from .transcriber import Transcriber
@@ -30,9 +31,10 @@ class RawSpeak:
         idle  ──hotkey──►  listening  ──hotkey──►  processing  ──done──►  idle
     """
 
-    def __init__(self) -> None:
+    def __init__(self, use_tk_ui: bool = True) -> None:
         self.config = load_config()
         write_default_config()
+        self.use_tk_ui = use_tk_ui
 
         self.recorder = AudioRecorder(
             sample_rate=self.config.sample_rate,
@@ -51,6 +53,16 @@ class RawSpeak:
             groq_model=self.config.groq_model,
         )
         self.paster = Paster()
+        self.history = HistoryStore()
+        self.ui = None
+        if self.use_tk_ui:
+            from .ui import HistoryWindow
+
+            self.ui = HistoryWindow(
+                entries=self.history.list_recent(),
+                on_close=self._quit,
+                on_toggle_recording=self._on_hotkey,
+            )
         self.tray = TrayApp(on_quit=self._quit)
         self.hotkey = HotkeyListener(
             hotkey=self.config.hotkey,
@@ -87,6 +99,8 @@ class RawSpeak:
             return
         self._recording = True
         logger.info("Recording started — press the hotkey again to stop")
+        if self.ui:
+            self.ui.set_state("listening")
         self.tray.set_state("listening")
 
     def _stop_and_process(self) -> None:
@@ -94,6 +108,8 @@ class RawSpeak:
         self._recording = False
         self._processing = True
         logger.info("Recording stopped — processing audio…")
+        if self.ui:
+            self.ui.set_state("processing")
         self.tray.set_state("processing")
         thread = threading.Thread(
             target=self._run_pipeline, daemon=True, name="rawspeak-pipeline"
@@ -126,6 +142,10 @@ class RawSpeak:
             cleaned = self.cleaner.clean(text)
             logger.info("Cleaned text: %r", cleaned)
 
+            entry = self.history.append(cleaned)
+            if self.ui:
+                self.ui.enqueue(entry)
+
             logger.info("Pasting…")
             self.paster.paste(cleaned)
             logger.info("Done!")
@@ -135,6 +155,8 @@ class RawSpeak:
         finally:
             with self._lock:
                 self._processing = False
+            if self.ui:
+                self.ui.set_state("idle")
             self.tray.set_state("idle")
 
     # ------------------------------------------------------------------
@@ -148,6 +170,9 @@ class RawSpeak:
         if self.recorder.is_recording:
             self.recorder.stop()
         self.hotkey.stop()
+        self.tray.stop()
+        if self.ui:
+            self.ui.stop()
         sys.exit(0)
 
     def run(self) -> None:
@@ -162,29 +187,64 @@ class RawSpeak:
             "(The Whisper model will be downloaded on first use if not cached.)"
         )
 
+        self._check_permissions()
         self.hotkey.start()
 
-        if sys.platform == "darwin":
-            # AppKit requires tray setup on the main thread on macOS.
-            try:
-                self.tray.run_blocking()
-                # If run_blocking returns, the tray backend likely failed to start.
-                # Keep the process alive so global hotkeys still work.
-                logger.warning(
-                    "Tray loop exited. Running without tray; hotkeys remain active."
-                )
-                self._stop_event.wait()
-            except KeyboardInterrupt:
-                self._quit()
-            except Exception:
-                logger.exception("Tray failed to start on macOS; running without tray")
-                self._stop_event.wait()
-        else:
+        # On macOS, pystray requires AppKit main-thread access and can clash
+        # with alternative UI loops; keep tray disabled there for reliability.
+        if sys.platform != "darwin":
             self.tray.start()
+
+        if self.use_tk_ui and self.ui:
+            try:
+                self.ui.run_blocking()
+            except KeyboardInterrupt:
+                self._quit()
+        else:
             try:
                 self._stop_event.wait()
             except KeyboardInterrupt:
                 self._quit()
+
+    def _check_permissions(self) -> None:
+        """Best-effort startup checks for required OS permissions."""
+        if sys.platform != "darwin":
+            return
+
+        warnings: list[str] = []
+
+        try:
+            from ApplicationServices import (
+                AXIsProcessTrusted,
+                AXIsProcessTrustedWithOptions,
+                kAXTrustedCheckOptionPrompt,
+            )
+
+            if not AXIsProcessTrusted():
+                AXIsProcessTrustedWithOptions({kAXTrustedCheckOptionPrompt: True})
+                warnings.append("Enable Accessibility for RawSpeak/Terminal in System Settings.")
+        except Exception:
+            warnings.append("Accessibility permission status could not be verified.")
+
+        try:
+            from Quartz import CGPreflightListenEventAccess, CGRequestListenEventAccess
+
+            if not CGPreflightListenEventAccess():
+                CGRequestListenEventAccess()
+                warnings.append("Enable Input Monitoring for RawSpeak/Terminal in System Settings.")
+        except Exception:
+            warnings.append("Input Monitoring permission status could not be verified.")
+
+        notice = (
+            "Permissions check: "
+            + (" ; ".join(warnings) if warnings else "looks good. Hotkey should work.")
+        )
+        if self.ui:
+            self.ui.set_notice(notice)
+        if warnings:
+            logger.warning(notice)
+        else:
+            logger.info(notice)
 
 
 def main() -> None:
@@ -206,7 +266,7 @@ def main() -> None:
         "command",
         nargs="?",
         default="run",
-        choices=["run", "install", "uninstall"],
+        choices=["run", "run-headless", "install", "uninstall"],
         help="'install' sets up auto-start at login; 'uninstall' removes it.",
     )
     args = parser.parse_args()
@@ -219,8 +279,11 @@ def main() -> None:
         from .launcher import uninstall
 
         uninstall()
+    elif args.command == "run-headless":
+        app = RawSpeak(use_tk_ui=False)
+        app.run()
     else:
-        app = RawSpeak()
+        app = RawSpeak(use_tk_ui=True)
         app.run()
 
 

--- a/rawspeak/ui.py
+++ b/rawspeak/ui.py
@@ -1,0 +1,144 @@
+"""Simple desktop UI that shows processed speech history."""
+
+from __future__ import annotations
+
+import queue
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable, Iterable, Optional
+
+from .history import HistoryEntry
+
+
+class HistoryWindow:
+    """Tiny Tkinter window showing timestamp + processed text rows."""
+
+    def __init__(
+        self,
+        entries: Iterable[HistoryEntry],
+        on_close: Optional[Callable[[], None]] = None,
+        on_toggle_recording: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self._on_close = on_close
+        self._on_toggle_recording = on_toggle_recording
+        self._queue: "queue.Queue[HistoryEntry]" = queue.Queue()
+
+        self.root = tk.Tk()
+        self.root.title("RawSpeak")
+        self.root.geometry("860x520")
+        self.root.minsize(640, 360)
+        self.root.protocol("WM_DELETE_WINDOW", self._handle_close)
+
+        container = ttk.Frame(self.root, padding=12)
+        container.pack(fill=tk.BOTH, expand=True)
+
+        title = ttk.Label(container, text="Processed speech", font=("Helvetica", 16, "bold"))
+        title.pack(anchor="w")
+
+        subtitle = ttk.Label(
+            container,
+            text="Newest items appear at the top.",
+            foreground="#666666",
+        )
+        subtitle.pack(anchor="w", pady=(2, 6))
+
+        self.notice_label = ttk.Label(
+            container,
+            text="",
+            foreground="#666666",
+        )
+        self.notice_label.pack(anchor="w", pady=(0, 8))
+
+        controls = ttk.Frame(container)
+        controls.pack(fill=tk.X, pady=(0, 8))
+
+        self.toggle_button = ttk.Button(
+            controls,
+            text="Start recording",
+            command=self._handle_toggle,
+        )
+        self.toggle_button.pack(side=tk.LEFT)
+
+        self.state_label = ttk.Label(
+            controls,
+            text="State: idle",
+            foreground="#666666",
+        )
+        self.state_label.pack(side=tk.LEFT, padx=(12, 0))
+
+        table_frame = ttk.Frame(container)
+        table_frame.pack(fill=tk.BOTH, expand=True)
+
+        self.table = ttk.Treeview(
+            table_frame,
+            columns=("time", "text"),
+            show="headings",
+        )
+        self.table.heading("time", text="Time")
+        self.table.heading("text", text="Text")
+        self.table.column("time", width=110, anchor="w", stretch=False)
+        self.table.column("text", anchor="w")
+
+        yscroll = ttk.Scrollbar(table_frame, orient="vertical", command=self.table.yview)
+        self.table.configure(yscrollcommand=yscroll.set)
+
+        self.table.grid(row=0, column=0, sticky="nsew")
+        yscroll.grid(row=0, column=1, sticky="ns")
+
+        table_frame.rowconfigure(0, weight=1)
+        table_frame.columnconfigure(0, weight=1)
+
+        for entry in entries:
+            self._insert(entry)
+
+        self.root.after(250, self._drain_queue)
+
+    def enqueue(self, entry: HistoryEntry) -> None:
+        self._queue.put(entry)
+
+    def set_state(self, state: str) -> None:
+        if state == "listening":
+            self.toggle_button.configure(text="Stop and process")
+            self.state_label.configure(text="State: listening")
+        elif state == "processing":
+            self.toggle_button.configure(text="Processing...")
+            self.state_label.configure(text="State: processing")
+        else:
+            self.toggle_button.configure(text="Start recording")
+            self.state_label.configure(text="State: idle")
+
+    def set_notice(self, message: str) -> None:
+        self.notice_label.configure(text=message)
+
+    def run_blocking(self) -> None:
+        self.root.mainloop()
+
+    def stop(self) -> None:
+        if self.root.winfo_exists():
+            self.root.quit()
+            self.root.destroy()
+
+    def _insert(self, entry: HistoryEntry) -> None:
+        if not entry.text:
+            return
+        self.table.insert("", 0, values=(entry.timestamp or "--", entry.text))
+
+    def _drain_queue(self) -> None:
+        while True:
+            try:
+                entry = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            self._insert(entry)
+        if self.root.winfo_exists():
+            self.root.after(250, self._drain_queue)
+
+    def _handle_toggle(self) -> None:
+        if self._on_toggle_recording is not None:
+            self._on_toggle_recording()
+
+    def _handle_close(self) -> None:
+        if self._on_close is not None:
+            self._on_close()
+        else:
+            self.stop()


### PR DESCRIPTION
## Summary
- add core history persistence and a simple local UI flow with headless backend mode
- introduce Electron app shell that runs the Python backend and displays processed speech history
- improve Electron UX (wrapped rows, row highlight, click-to-copy, per-row copy action, toast)
- add tray status indicator logic and stream state parsing from backend logs
- improve macOS hotkey reliability with Quartz listener path and startup permission checks

## Related
- #10

## Test plan
- [x] `pytest`
- [x] Run `python -m rawspeak.main`
- [x] Run `python -m rawspeak.main run-headless`
- [x] Run `cd electron && npm start`

Made with [Cursor](https://cursor.com)