### PR TITLE
fix: #4 repair first-install macOS app launch and release guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: pyinstaller rawspeak.spec --noconfirm
 
+      - name: Smoke test packaged app
+        if: steps.check.outputs.exists == 'false'
+        run: ./dist/RawSpeak.app/Contents/MacOS/RawSpeak --help
+
       - name: Install create-dmg
         if: steps.check.outputs.exists == 'false'
         run: brew install create-dmg
@@ -79,8 +83,7 @@ jobs:
             --hide-extension "RawSpeak.app" \
             --app-drop-link 600 185 \
             "dist/RawSpeak-${VERSION}.dmg" \
-            "dist/dmg/" \
-            || true
+            "dist/dmg/"
           ls -lh dist/*.dmg
 
       - name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 rawspeak.egg-info/
 assets/*.iconset/
 electron/node_modules/
+build/
+dist/

--- a/app_entry.py
+++ b/app_entry.py
@@ -1,0 +1,7 @@
+"""PyInstaller entrypoint for launching RawSpeak as a package."""
+
+from rawspeak.main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rawspeak"
-version = "0.1.5"
+version = "0.1.6"
 description = "Local voice-to-text desktop tool — privacy-first Whisper + LLM dictation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/rawspeak.spec
+++ b/rawspeak.spec
@@ -7,9 +7,19 @@ from pathlib import Path
 block_cipher = None
 
 APP_ICON = "assets/RawSpeak.icns"
+APP_VERSION = "0.0.0"
+
+try:
+    ns = {}
+    init_path = Path(__file__).resolve().parent / "rawspeak" / "__init__.py"
+    exec(init_path.read_text(encoding="utf-8"), ns)
+    APP_VERSION = str(ns.get("__version__", APP_VERSION))
+except Exception:
+    # Keep build resilient; release CI reads version independently.
+    pass
 
 a = Analysis(
-    ["rawspeak/main.py"],
+    ["app_entry.py"],
     pathex=["."],
     binaries=[],
     datas=[],
@@ -35,7 +45,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=["tkinter", "matplotlib", "IPython", "notebook", "scipy"],
+    excludes=["matplotlib", "IPython", "notebook", "scipy"],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,
@@ -75,7 +85,7 @@ app = BUNDLE(
     bundle_identifier="com.rawspeak.app",
     icon=APP_ICON,
     info_plist={
-        "CFBundleShortVersionString": "0.1.5",
+        "CFBundleShortVersionString": APP_VERSION,
         "CFBundleName": "RawSpeak",
         "CFBundleDisplayName": "RawSpeak",
         "NSMicrophoneUsageDescription": "RawSpeak needs microphone access to record your voice for transcription.",

--- a/rawspeak/__init__.py
+++ b/rawspeak/__init__.py
@@ -1,3 +1,3 @@
 """rawspeak - Local voice-to-text desktop tool."""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
## Summary
- fix packaging so shipped app boots reliably by using a package-safe PyInstaller entrypoint and including Tk runtime dependencies
- harden release CI by smoke-testing the packaged app and failing on DMG build errors instead of masking them
- bump release version to `0.1.6` for the corrected macOS install experience

## Related Issues
- #4

## Test plan
- [x] Local packaged app smoke test: `./dist/RawSpeak.app/Contents/MacOS/RawSpeak --help`
- [x] Validate local rebuild launches and reaches startup logs without import crash
- [ ] Confirm GitHub Actions release run for `0.1.6` uploads a working DMG artifact

Made with [Cursor](https://cursor.com)