### PR TITLE
feat(stt): replace Whisper with Moonshine Voice + improve LLM cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ assets/*.iconset/
 electron/node_modules/
 build/
 dist/
+docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,21 +5,18 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "rawspeak"
 version = "0.1.7"
-description = "Local voice-to-text desktop tool — privacy-first Whisper + LLM dictation"
+description = "Local voice-to-text desktop tool — privacy-first Moonshine + LLM dictation"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.14"
 license = { text = "MIT" }
 authors = [{ name = "rawspeak contributors" }]
-keywords = ["voice", "speech", "transcription", "whisper", "dictation", "privacy"]
+keywords = ["voice", "speech", "transcription", "moonshine", "dictation", "privacy"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Sound/Audio :: Speech",
     "Topic :: Utilities",
 ]
@@ -29,17 +26,16 @@ dependencies = [
     # Microphone capture
     "sounddevice>=0.4",
     "numpy>=1.24",
-    # Local Whisper transcription
-    "transformers>=4.35",
-    "torch>=2.0",
+    # Local Moonshine Voice transcription (on-device STT, no API key needed).
+    # Models are cached in ~/.cache/moonshine_voice after first download.
+    # Replaces the previous transformers+torch Whisper stack.
+    "moonshine-voice>=0.0.50",
     # Clipboard + auto-paste
     "pyperclip>=1.8",
     "pyautogui>=0.9",
     # System tray icon
     "pystray>=0.19",
     "Pillow>=9.0",
-    # TOML config parsing (stdlib in Python 3.11+)
-    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/rawspeak/cleaner.py
+++ b/rawspeak/cleaner.py
@@ -11,18 +11,54 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Prompt sent to the LLM
+# Prompts sent to the LLM
 # ---------------------------------------------------------------------------
 
-_CLEANUP_PROMPT = (
-    "Clean up the following transcribed speech. "
-    "Remove filler words (um, uh, like, you know, sort of, kind of, basically, "
-    "literally, actually when used as filler), fix grammar and punctuation, "
-    "remove false starts and repetitions, and make the text read as clearly typed "
-    "prose suitable for use as an AI prompt. Preserve the original meaning. "
-    "Return ONLY the cleaned text — no explanation, no preamble.\n\n"
-    "Transcription: {text}"
-)
+# System-level instructions — used as the ``system`` role for Groq and as the
+# ``system`` field for Ollama /api/generate.
+_SYSTEM_PROMPT = """\
+You are a speech-to-text post-processor. Convert raw, imperfect voice \
+transcriptions into clean, professional text ready to send in an email, \
+message, or chat — or for an AI agent to act on.
+
+Rules:
+1. Fix all grammar and spelling errors.
+2. Add proper punctuation: commas, periods, apostrophes, and correct \
+capitalisation for every sentence.
+3. Remove filler words: um, uh, like, you know, basically, literally (when \
+used as filler), sort of, kind of, I mean.
+4. Handle spoken self-corrections: when the speaker corrects themselves \
+("X sorry Y", "X sorry sorry Y", "X I mean Y", "X wait Y", "X no Y"), \
+discard the error (X) and the correction marker, and keep only the intended \
+correction (Y).
+5. Remove false starts and accidental word repetitions \
+(e.g. "For for tomorrow" → "for tomorrow").
+6. Fix context-obvious mishearings using surrounding words \
+(e.g. "set all around for 1 a.m." → "set an alarm for 1 a.m.").
+7. Preserve the original meaning exactly — do NOT add, remove, or reorder \
+ideas. Do NOT summarise or paraphrase.
+8. Output ONLY the cleaned text — no explanation, no preamble, no surrounding \
+quotes.
+
+Examples:
+
+Input: "uh hello my name is john and I want to um schedule a meeting for \
+monday I mean tuesday at 3 p.m"
+Output: Hello, my name is John, and I want to schedule a meeting for Tuesday \
+at 3 p.m.
+
+Input: "I want to say to the alarm for 12 a.m sorry sorry 1 a.m I'm be ready \
+For for tomorrow Yes."
+Output: I want to set an alarm for 1 a.m. so I'll be ready for tomorrow.
+
+Input: "yes it did not work but I'll try again I want to set all around for \
+12 a.m sorry sorry one a.m and then I'm gonna do something else"
+Output: Yes, it did not work, but I'll try again. I want to set an alarm for \
+1 a.m., and then I'm going to do something else.\
+"""
+
+# User-turn template — the raw transcription handed to the model.
+_USER_TEMPLATE = "Raw transcription:\n{text}"
 
 
 class TextCleaner:
@@ -33,6 +69,11 @@ class TextCleaner:
     * ``"ollama"`` — calls a local Ollama server; falls back to rule-based on error.
     * ``"groq"``   — calls the Groq API;  falls back to rule-based on error.
     * ``"none"``   — rule-based only (no network requests).
+
+    *user_glossary* maps STT-mangled strings to their correct form
+    (e.g. ``{"Jhunjhun": "Zinjad"}``).  Substitutions are applied
+    case-insensitively *before* the LLM call so the model never sees the
+    garbled version.
     """
 
     def __init__(
@@ -42,12 +83,14 @@ class TextCleaner:
         ollama_model: str = "llama3.2:3b",
         groq_api_key: str = "",
         groq_model: str = "llama-3.1-8b-instant",
+        user_glossary: dict[str, str] | None = None,
     ) -> None:
         self.backend = backend
         self.ollama_url = ollama_url.rstrip("/")
         self.ollama_model = ollama_model
         self.groq_api_key = groq_api_key
         self.groq_model = groq_model
+        self.user_glossary: dict[str, str] = user_glossary or {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -56,10 +99,13 @@ class TextCleaner:
     def clean(self, text: str) -> str:
         """Return a cleaned version of *text*.
 
-        Falls back to rule-based cleanup when the configured backend fails.
+        Applies the user glossary first, then calls the configured LLM
+        backend.  Falls back to rule-based cleanup when the backend fails.
         """
         if not text.strip():
             return text
+
+        text = _apply_glossary(text, self.user_glossary)
 
         if self.backend == "ollama":
             try:
@@ -86,7 +132,8 @@ class TextCleaner:
         url = f"{self.ollama_url}/api/generate"
         payload = {
             "model": self.ollama_model,
-            "prompt": _CLEANUP_PROMPT.format(text=text),
+            "system": _SYSTEM_PROMPT,
+            "prompt": _USER_TEMPLATE.format(text=text),
             "stream": False,
         }
         data = json.dumps(payload).encode()
@@ -109,7 +156,8 @@ class TextCleaner:
         payload = {
             "model": self.groq_model,
             "messages": [
-                {"role": "user", "content": _CLEANUP_PROMPT.format(text=text)},
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": _USER_TEMPLATE.format(text=text)},
             ],
             "temperature": 0.3,
             "max_tokens": 1024,
@@ -130,6 +178,23 @@ class TextCleaner:
 
 
 # ---------------------------------------------------------------------------
+# Glossary substitution
+# ---------------------------------------------------------------------------
+
+
+def _apply_glossary(text: str, glossary: dict[str, str]) -> str:
+    """Replace STT-mangled tokens with their correct forms.
+
+    Matching is whole-word and case-insensitive; replacement preserves
+    the casing supplied in *glossary*.
+    """
+    for wrong, right in glossary.items():
+        pattern = re.compile(r"\b" + re.escape(wrong) + r"\b", re.IGNORECASE)
+        text = pattern.sub(right, text)
+    return text
+
+
+# ---------------------------------------------------------------------------
 # Rule-based fallback
 # ---------------------------------------------------------------------------
 
@@ -146,10 +211,19 @@ _FILLER_RE = re.compile(
     flags=re.IGNORECASE,
 )
 
+# Consecutive identical words: "For for" → "For", "the the" → "the".
+_REPEAT_WORD_RE = re.compile(r"\b(\w+)(\s+\1)+\b", re.IGNORECASE)
+
+# Spoken self-correction marker: "... sorry sorry" or lone trailing "sorry".
+# Removes the marker; the LLM handles the preceding erroneous word.
+_DOUBLE_SORRY_RE = re.compile(r"\bsorry\s+sorry\b", re.IGNORECASE)
+
 
 def _rule_based_clean(text: str) -> str:
     """Remove common speech fillers and tidy whitespace."""
     result = _FILLER_RE.sub("", text)
+    result = _DOUBLE_SORRY_RE.sub("", result)
+    result = _REPEAT_WORD_RE.sub(r"\1", result)
     # Collapse multiple spaces.
     result = re.sub(r"\s{2,}", " ", result)
     # Remove spaces before punctuation.

--- a/rawspeak/config.py
+++ b/rawspeak/config.py
@@ -3,22 +3,10 @@
 from __future__ import annotations
 
 import os
-import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
-# Python 3.11+ includes tomllib in stdlib; older versions need tomli.
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomllib  # type: ignore[no-redef]
-    except ImportError:
-        try:
-            import tomli as tomllib  # type: ignore[no-redef]
-        except ImportError:
-            tomllib = None  # type: ignore[assignment]
+import tomllib
 
 CONFIG_DIR = Path.home() / ".config" / "rawspeak"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
@@ -39,17 +27,22 @@ hotkey = "<ctrl>+<alt>+<space>"
 mouse_button = "middle"
 
 # Audio capture settings.
-sample_rate = 16000  # Hz — Whisper expects 16 kHz
+sample_rate = 16000  # Hz — Moonshine expects 16 kHz (resamples if different)
 channels    = 1      # Mono
 
-# HuggingFace Whisper model identifier.
-# Smaller = faster; larger = more accurate.
-# Options: "openai/whisper-tiny", "openai/whisper-base", "openai/whisper-small"
-whisper_model = "openai/whisper-base"
+# Moonshine Voice model size for speech-to-text transcription.
+# All models run fully local — no internet required after first download.
+# Models are cached in ~/.cache/moonshine_voice after the first run.
+#
+# Options (accuracy improves, speed decreases top to bottom):
+#   "tiny"             — 26 M params,  ~12.7% WER, fastest
+#   "base"             — 58 M params,  ~10.1% WER, balanced CPU option
+#   "small_streaming"  — 123 M params,  ~7.8% WER, good for mid-range hardware
+#   "medium_streaming" — 245 M params,  ~6.7% WER, beats Whisper Large-v3
+transcriber_model = "medium_streaming"
 
 # Spoken language for transcription (ISO 639-1 code, e.g. "en").
-# Forces Whisper to skip language detection and transcribe directly in this language,
-# which is faster and avoids hallucination on background noise.
+# Supported: en, es, zh, ja, ko, vi, ar, uk
 language = "en"
 
 # Text-cleanup backend: "ollama" | "groq" | "none"
@@ -66,6 +59,15 @@ groq_model = "llama-3.1-8b-instant"
 
 # Show a desktop notification after each successful paste.
 show_notifications = true
+
+# User glossary — teach RawSpeak proper nouns or words your STT engine
+# consistently mishears.  Add one entry per line under [glossary]:
+#   wrong_form = "correct form"
+# Matching is whole-word and case-insensitive.
+#
+# [glossary]
+# "Jhunjhun" = "Zinjad"
+# "Suryabh"  = "Saurabh"
 """
 
 
@@ -78,10 +80,10 @@ class Config:
     # Audio
     sample_rate: int = 16000
     channels: int = 1
-    device: Optional[str] = None  # None → system default
+    device: str | None = None  # None → system default
 
     # Transcription
-    whisper_model: str = "openai/whisper-base"
+    transcriber_model: str = "medium_streaming"
     language: str = "en"
 
     # Cleanup
@@ -98,6 +100,10 @@ class Config:
     # UI
     show_notifications: bool = True
 
+    # User glossary: correct words the STT engine mishears.
+    # Populated from the [glossary] section of config.toml.
+    user_glossary: dict[str, str] = field(default_factory=dict)
+
 
 def load_config() -> Config:
     """Load configuration, merging file values on top of defaults."""
@@ -110,14 +116,13 @@ def load_config() -> Config:
     if not CONFIG_FILE.exists():
         return config
 
-    if tomllib is None:
-        return config
-
     try:
         with open(CONFIG_FILE, "rb") as fh:
             data = tomllib.load(fh)
         for key, value in data.items():
-            if hasattr(config, key):
+            if key == "glossary" and isinstance(value, dict):
+                config.user_glossary = {str(k): str(v) for k, v in value.items()}
+            elif hasattr(config, key):
                 setattr(config, key, value)
     except Exception:
         pass  # silently use defaults if the file is malformed

--- a/rawspeak/main.py
+++ b/rawspeak/main.py
@@ -42,7 +42,7 @@ class RawSpeak:
             device=self.config.device,
         )
         self.transcriber = Transcriber(
-            model_name=self.config.whisper_model,
+            model_size=self.config.transcriber_model,
             language=self.config.language,
         )
         self.cleaner = TextCleaner(
@@ -51,6 +51,7 @@ class RawSpeak:
             ollama_model=self.config.ollama_model,
             groq_api_key=self.config.groq_api_key,
             groq_model=self.config.groq_model,
+            user_glossary=self.config.user_glossary,
         )
         self.paster = Paster()
         self.history = HistoryStore()
@@ -180,11 +181,11 @@ class RawSpeak:
         logger.info(
             "rawspeak ready  |  hotkey: %s  |  model: %s  |  cleanup: %s",
             self.config.hotkey,
-            self.config.whisper_model,
+            self.config.transcriber_model,
             self.config.cleanup_backend,
         )
         logger.info(
-            "(The Whisper model will be downloaded on first use if not cached.)"
+            "(Moonshine model will be downloaded on first use if not cached.)"
         )
 
         self._check_permissions()

--- a/rawspeak/transcriber.py
+++ b/rawspeak/transcriber.py
@@ -1,4 +1,4 @@
-"""Whisper transcription via HuggingFace *transformers*."""
+"""Moonshine Voice speech-to-text transcription."""
 
 from __future__ import annotations
 
@@ -8,18 +8,32 @@ import numpy as np
 
 
 class Transcriber:
-    """Transcribes audio to text using a local Whisper model.
+    """Transcribes audio to text using Moonshine Voice.
 
     The model is loaded lazily on the first call to :meth:`transcribe` so that
     startup time is kept low.
+
+    Model size options (``model_size`` constructor arg):
+
+    +-----------------------+------------+----------+-----------------------------+
+    | model_size            | Params     | WER      | Notes                       |
+    +=======================+============+==========+=============================+
+    | ``tiny``              | 26 M       | ~12.7 %  | Fastest, lowest accuracy    |
+    | ``base``              | 58 M       | ~10.1 %  | Balanced CPU option         |
+    | ``small_streaming``   | 123 M      | ~7.8 %   | Good for mid-range hardware |
+    | ``medium_streaming``  | 245 M      | ~6.7 %   | **Default** — best accuracy |
+    +-----------------------+------------+----------+-----------------------------+
+
+    Moonshine Medium Streaming beats Whisper Large-v3 (7.4 % WER) at 1/6 the
+    parameters and completes in ~107 ms on Apple Silicon.
     """
 
     def __init__(
-        self, model_name: str = "openai/whisper-base", language: str = "en"
+        self, model_size: str = "medium_streaming", language: str = "en"
     ) -> None:
-        self.model_name = model_name
+        self.model_size = model_size
         self.language = language
-        self._pipeline = None
+        self._transcriber = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -29,78 +43,77 @@ class Transcriber:
         """Transcribe *audio* to text.
 
         Args:
-            audio: Float32 numpy array of audio samples.
-            sample_rate: Sample rate of *audio* (Whisper expects 16 000 Hz).
+            audio: Float32 numpy array of mono audio samples in [-1.0, 1.0].
+            sample_rate: Sample rate of *audio*. Moonshine resamples internally
+                so any rate is accepted; 16 kHz avoids the resample overhead.
 
         Returns:
             Transcribed text, stripped of leading/trailing whitespace.
+            Returns an empty string for silent or empty audio.
         """
         if len(audio) == 0:
             return ""
 
         self._load_model()
 
-        if sample_rate != 16000:
-            audio = _resample(audio, sample_rate, 16000)
+        # Moonshine Voice expects a plain Python list of float32 values.
+        audio_list = audio.astype(np.float32).tolist()
 
-        result = self._pipeline(
-            {"array": audio, "sampling_rate": 16000},
-            return_timestamps=True,  # required for audio > 30 s; safe for shorter audio too
-            generate_kwargs={"language": self.language, "task": "transcribe"},
+        transcript = self._transcriber.transcribe_without_streaming(
+            audio_list, sample_rate
         )
-        text = result.get("text", "").strip()
+        text = " ".join(line.text for line in transcript.lines).strip()
+
         if _is_hallucination(text):
             return ""
+
         return text
+
+    def close(self) -> None:
+        """Release Moonshine model resources."""
+        if self._transcriber is not None:
+            self._transcriber.close()
+            self._transcriber = None
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
     def _load_model(self) -> None:
-        """Lazy-load the Whisper ASR pipeline."""
-        if self._pipeline is not None:
+        """Lazy-load the Moonshine transcriber (downloads model on first use)."""
+        if self._transcriber is not None:
             return
 
-        import torch
-        from transformers import pipeline
+        from moonshine_voice import (  # type: ignore[import-untyped]
+            ModelArch,
+            Transcriber as _MoonshineTranscriber,
+            get_model_for_language,
+        )
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        self._pipeline = pipeline(
-            "automatic-speech-recognition",
-            model=self.model_name,
-            device=device,
+        _ARCH_MAP: dict[str, object] = {
+            "tiny": ModelArch.TINY,
+            "base": ModelArch.BASE,
+            "small_streaming": ModelArch.SMALL_STREAMING,
+            "medium_streaming": ModelArch.MEDIUM_STREAMING,
+        }
+
+        # Downloads and caches the model under ~/.cache/moonshine_voice on
+        # first run; subsequent calls are instant (cache hit).
+        model_path, _ = get_model_for_language(self.language)
+        model_arch = _ARCH_MAP.get(self.model_size, ModelArch.MEDIUM_STREAMING)
+
+        self._transcriber = _MoonshineTranscriber(
+            model_path=model_path,
+            model_arch=model_arch,
         )
 
 
-def _resample(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
-    """Resample *audio* from *orig_sr* to *target_sr*.
-
-    Uses *resampy* when available, otherwise falls back to linear interpolation.
-    """
-    if orig_sr == target_sr:
-        return audio
-
-    try:
-        import resampy  # type: ignore[import-untyped]
-
-        return resampy.resample(audio, orig_sr, target_sr)
-    except ImportError:
-        pass
-
-    # Naive fallback via linear interpolation.
-    target_len = int(len(audio) * target_sr / orig_sr)
-    indices = np.linspace(0, len(audio) - 1, target_len)
-    return np.interp(indices, np.arange(len(audio)), audio).astype(np.float32)
-
-
 def _is_hallucination(text: str) -> bool:
-    """Return True when the output is a repetitive Whisper hallucination.
+    """Return True when output appears to be a repetitive hallucination.
 
-    Whisper on multilingual models (or on silence/background noise) sometimes
-    loops a single token thousands of times, e.g. ``"asa, asa, asa, ..."``.
-    We detect this by checking whether a single word makes up more than half
-    of all words in the output.
+    Checks whether a single word accounts for more than half of all words.
+    This catches looping artefacts where the model emits the same token
+    hundreds of times instead of real speech content.
     """
     words = re.findall(r"\b\w+\b", text.lower())
     if len(words) < 8:

--- a/scripts/test_stt.py
+++ b/scripts/test_stt.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Quick interactive test for the Moonshine STT engine.
+
+Usage:
+    .venv/bin/python scripts/test_stt.py
+
+Steps:
+    1. Press Enter to START recording
+    2. Speak into your microphone
+    3. Press Enter to STOP and transcribe
+    4. See raw Moonshine output + timing
+    5. Repeat as many times as you want — Ctrl+C to quit
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+# Allow running from repo root without installing
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import numpy as np
+import sounddevice as sd
+
+from rawspeak.transcriber import Transcriber
+
+SAMPLE_RATE = 16_000
+CHANNELS = 1
+
+# ── Pre-load model once ───────────────────────────────────────────────────────
+print("Loading Moonshine medium_streaming model… ", end="", flush=True)
+t0 = time.perf_counter()
+transcriber = Transcriber(model_size="medium_streaming", language="en")
+transcriber._load_model()          # force eager load so timing is honest
+load_ms = (time.perf_counter() - t0) * 1000
+print(f"done ({load_ms:.0f} ms)\n")
+
+# ── Interactive loop ──────────────────────────────────────────────────────────
+round_num = 0
+try:
+    while True:
+        round_num += 1
+        print(f"─── Round {round_num} ───────────────────────────────")
+        input("  Press Enter to START recording…")
+
+        frames: list[np.ndarray] = []
+
+        def _callback(indata, frame_count, time_info, status):
+            frames.append(indata.copy())
+
+        stream = sd.InputStream(
+            samplerate=SAMPLE_RATE,
+            channels=CHANNELS,
+            dtype="float32",
+            callback=_callback,
+        )
+
+        with stream:
+            print("  🎙  Recording — press Enter to STOP…")
+            input()
+
+        audio = np.concatenate(frames, axis=0).squeeze()
+        duration = len(audio) / SAMPLE_RATE
+        print(f"  Captured {duration:.1f}s of audio")
+
+        if duration < 0.3:
+            print("  Too short — skipping\n")
+            continue
+
+        print("  Transcribing… ", end="", flush=True)
+        t0 = time.perf_counter()
+        text = transcriber.transcribe(audio, sample_rate=SAMPLE_RATE)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        print(f"done ({elapsed_ms:.0f} ms)")
+        print()
+        if text:
+            print(f"  Result : \"{text}\"")
+        else:
+            print("  Result : (empty — silence or hallucination filtered)")
+        print()
+
+except KeyboardInterrupt:
+    print("\nDone.")
+finally:
+    transcriber.close()

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from rawspeak.cleaner import TextCleaner, _rule_based_clean
+from rawspeak.cleaner import TextCleaner, _apply_glossary, _rule_based_clean
 
 
 class TestRuleBasedClean:
@@ -35,6 +35,44 @@ class TestRuleBasedClean:
         result = _rule_based_clean("I need to go to the store")
         assert "store" in result
 
+    def test_removes_consecutive_word_repetition(self):
+        result = _rule_based_clean("I need to go For for tomorrow")
+        assert "for for" not in result.lower()
+        assert "tomorrow" in result.lower()
+
+    def test_removes_double_sorry(self):
+        result = _rule_based_clean("set an alarm for 1 a.m sorry sorry yes")
+        assert "sorry sorry" not in result.lower()
+
+    def test_three_word_repetition(self):
+        result = _rule_based_clean("the the the store")
+        assert "the the" not in result.lower()
+
+
+class TestApplyGlossary:
+    def test_replaces_exact_match(self):
+        result = _apply_glossary("Hello Jhunjhun", {"Jhunjhun": "Zinjad"})
+        assert result == "Hello Zinjad"
+
+    def test_case_insensitive_match(self):
+        result = _apply_glossary("Hello jhunjhun", {"Jhunjhun": "Zinjad"})
+        assert "Zinjad" in result
+
+    def test_whole_word_only(self):
+        # Should not replace "Jhunjhuns" (different word form)
+        result = _apply_glossary("Jhunjhuns party", {"Jhunjhun": "Zinjad"})
+        assert "Jhunjhuns" in result
+
+    def test_empty_glossary(self):
+        assert _apply_glossary("hello world", {}) == "hello world"
+
+    def test_multiple_entries(self):
+        result = _apply_glossary(
+            "Suryabh Jhunjhaj",
+            {"Suryabh": "Saurabh", "Jhunjhaj": "Zinjad"},
+        )
+        assert result == "Saurabh Zinjad"
+
 
 class TestTextCleanerNoneBackend:
     def test_uses_rule_based(self):
@@ -48,6 +86,12 @@ class TestTextCleanerNoneBackend:
         cleaner = TextCleaner(backend="none")
         assert cleaner.clean("") == ""
         assert cleaner.clean("   ") == "   "
+
+    def test_glossary_applied_before_rule_based(self):
+        cleaner = TextCleaner(backend="none", user_glossary={"Jhunjhun": "Zinjad"})
+        result = cleaner.clean("Hello Jhunjhun")
+        assert "Jhunjhun" not in result
+        assert "Zinjad" in result
 
 
 class TestTextCleanerOllamaBackend:
@@ -65,6 +109,25 @@ class TestTextCleanerOllamaBackend:
 
         assert result == "I need to go to the store."
 
+    def test_ollama_payload_includes_system(self):
+        """Ollama request must include the system prompt field."""
+        cleaner = TextCleaner(backend="ollama")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"response": "ok"}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner._clean_ollama("test input")
+
+        assert "system" in captured[0]
+        assert len(captured[0]["system"]) > 50  # non-trivial system prompt
+
     def test_falls_back_to_rule_based_on_error(self):
         cleaner = TextCleaner(backend="ollama")
 
@@ -73,6 +136,26 @@ class TestTextCleanerOllamaBackend:
 
         assert "um" not in result.lower()
         assert "test" in result.lower()
+
+    def test_glossary_applied_before_llm_call(self):
+        """Glossary substitution happens before the text is sent to Ollama."""
+        cleaner = TextCleaner(backend="ollama", user_glossary={"Jhunjhun": "Zinjad"})
+        sent_prompts: list[str] = []
+
+        def fake_urlopen(req, timeout=30):
+            payload = json.loads(req.data.decode())
+            sent_prompts.append(payload.get("prompt", ""))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"response": "Hello Zinjad."}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner.clean("Hello Jhunjhun")
+
+        assert "Jhunjhun" not in sent_prompts[0]
+        assert "Zinjad" in sent_prompts[0]
 
 
 class TestTextCleanerGroqBackend:
@@ -96,6 +179,27 @@ class TestTextCleanerGroqBackend:
             result = cleaner._clean_groq("um some text uh here")
 
         assert result == "Cleaned text."
+
+    def test_groq_payload_has_system_role(self):
+        """Groq request must include a system role message."""
+        cleaner = TextCleaner(backend="groq", groq_api_key="test-key")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(
+                {"choices": [{"message": {"content": "ok"}}]}
+            ).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner._clean_groq("test input")
+
+        roles = [m["role"] for m in captured[0]["messages"]]
+        assert "system" in roles
 
     def test_falls_back_to_rule_based_on_error(self):
         cleaner = TextCleaner(backend="groq", groq_api_key="test-key")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,8 +16,8 @@ class TestConfigDefaults:
     def test_default_sample_rate(self):
         assert Config().sample_rate == 16000
 
-    def test_default_whisper_model(self):
-        assert Config().whisper_model == "openai/whisper-base"
+    def test_default_transcriber_model(self):
+        assert Config().transcriber_model == "medium_streaming"
 
     def test_default_cleanup_backend(self):
         assert Config().cleanup_backend == "ollama"
@@ -38,10 +38,10 @@ class TestLoadConfig:
 
     def test_loads_values_from_toml_file(self, tmp_path, monkeypatch):
         cfg_file = tmp_path / "config.toml"
-        cfg_file.write_text('whisper_model = "openai/whisper-tiny"\nsample_rate = 8000\n')
+        cfg_file.write_text('transcriber_model = "small_streaming"\nsample_rate = 8000\n')
         monkeypatch.setattr("rawspeak.config.CONFIG_FILE", cfg_file)
         config = load_config()
-        assert config.whisper_model == "openai/whisper-tiny"
+        assert config.transcriber_model == "small_streaming"
         assert config.sample_rate == 8000
 
     def test_ignores_unknown_keys_in_toml(self, tmp_path, monkeypatch):

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,103 +1,179 @@
-"""Tests for rawspeak.transcriber — Transcriber and _resample."""
+"""Tests for rawspeak.transcriber — Transcriber and _is_hallucination."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
-from rawspeak.transcriber import Transcriber, _resample, _is_hallucination
+from rawspeak.transcriber import Transcriber, _is_hallucination
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_transcript(*texts: str) -> object:
+    """Build a fake moonshine_voice Transcript with the given line texts."""
+    lines = [SimpleNamespace(text=t) for t in texts]
+    return SimpleNamespace(lines=lines)
+
+
+def _transcriber_with_mock(mock_fn) -> Transcriber:
+    """Return a Transcriber whose internal moonshine handle is pre-mocked."""
+    t = Transcriber()
+    mock_handle = MagicMock()
+    mock_handle.transcribe_without_streaming.side_effect = mock_fn
+    t._transcriber = mock_handle
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Transcriber
+# ---------------------------------------------------------------------------
 
 class TestTranscriber:
     def test_empty_audio_returns_empty_string(self):
         t = Transcriber()
         assert t.transcribe(np.array([], dtype=np.float32)) == ""
 
-    def test_calls_pipeline_with_correct_inputs(self):
-        t = Transcriber(model_name="openai/whisper-base")
-        mock_pipeline = MagicMock(return_value={"text": " hello world "})
-        t._pipeline = mock_pipeline
-
-        audio = np.zeros(16000, dtype=np.float32)
-        result = t.transcribe(audio, sample_rate=16000)
-
-        assert result == "hello world"
-        call_args = mock_pipeline.call_args
-        assert call_args[0][0]["sampling_rate"] == 16000
-        assert len(call_args[0][0]["array"]) == 16000
-
-    def test_passes_language_and_task_in_generate_kwargs(self):
-        t = Transcriber(language="fr")
-        t._pipeline = MagicMock(return_value={"text": "bonjour"})
-
-        t.transcribe(np.zeros(16000, dtype=np.float32))
-
-        _, kwargs = t._pipeline.call_args
-        assert kwargs["generate_kwargs"]["language"] == "fr"
-        assert kwargs["generate_kwargs"]["task"] == "transcribe"
-
-    def test_hallucinated_output_returns_empty_string(self):
-        t = Transcriber()
-        # Simulate the "asa, asa, asa, ..." hallucination pattern
-        hallucination = ", ".join(["asa"] * 50)
-        t._pipeline = MagicMock(return_value={"text": hallucination})
-
+    def test_returns_joined_line_text(self):
+        t = _transcriber_with_mock(
+            lambda audio, sr: _make_transcript("Hello", "world")
+        )
         result = t.transcribe(np.zeros(16000, dtype=np.float32))
+        assert result == "Hello world"
 
-        assert result == ""
-
-    def test_strips_whitespace_from_pipeline_output(self):
-        t = Transcriber()
-        t._pipeline = MagicMock(return_value={"text": "   padded text   "})
+    def test_strips_whitespace(self):
+        t = _transcriber_with_mock(
+            lambda audio, sr: _make_transcript("  padded text  ")
+        )
         result = t.transcribe(np.zeros(16000, dtype=np.float32))
         assert result == "padded text"
 
-    def test_handles_missing_text_key(self):
-        t = Transcriber()
-        t._pipeline = MagicMock(return_value={"chunks": []})
+    def test_single_line_transcript(self):
+        t = _transcriber_with_mock(
+            lambda audio, sr: _make_transcript("hello world")
+        )
+        result = t.transcribe(np.zeros(16000, dtype=np.float32))
+        assert result == "hello world"
+
+    def test_empty_transcript_lines_returns_empty_string(self):
+        t = _transcriber_with_mock(lambda audio, sr: _make_transcript())
         result = t.transcribe(np.zeros(16000, dtype=np.float32))
         assert result == ""
 
-    def test_resamples_when_sample_rate_differs(self):
-        t = Transcriber()
+    def test_hallucinated_output_returns_empty_string(self):
+        hallucination = " ".join(["asa"] * 50)
+        t = _transcriber_with_mock(
+            lambda audio, sr: _make_transcript(hallucination)
+        )
+        result = t.transcribe(np.zeros(16000, dtype=np.float32))
+        assert result == ""
+
+    def test_passes_sample_rate_to_moonshine(self):
         received = {}
 
-        def capture_pipeline(inputs, **kwargs):
-            received.update(inputs)
-            return {"text": "ok"}
+        def capture(audio, sr):
+            received["sr"] = sr
+            return _make_transcript("ok")
 
-        t._pipeline = capture_pipeline
-        # 8 kHz audio → should be upsampled to 16 kHz before passing to pipeline
-        audio_8k = np.ones(8000, dtype=np.float32)
-        t.transcribe(audio_8k, sample_rate=8000)
+        t = _transcriber_with_mock(capture)
+        t.transcribe(np.zeros(8000, dtype=np.float32), sample_rate=8000)
+        assert received["sr"] == 8000
 
-        assert received["sampling_rate"] == 16000
-        assert len(received["array"]) == 16000
+    def test_audio_converted_to_list_of_floats(self):
+        received = {}
+
+        def capture(audio, sr):
+            received["audio"] = audio
+            return _make_transcript("ok")
+
+        t = _transcriber_with_mock(capture)
+        t.transcribe(np.ones(100, dtype=np.float32))
+        assert isinstance(received["audio"], list)
+        assert all(isinstance(v, float) for v in received["audio"])
+
+    def test_close_clears_internal_transcriber(self):
+        t = Transcriber()
+        mock_handle = MagicMock()
+        t._transcriber = mock_handle
+        t.close()
+        mock_handle.close.assert_called_once()
+        assert t._transcriber is None
+
+    def test_close_is_safe_when_not_loaded(self):
+        t = Transcriber()
+        t.close()  # must not raise
+
+    def test_load_model_uses_correct_arch(self):
+        """_load_model maps the config string to the right ModelArch enum."""
+        for model_size, arch_name in [
+            ("tiny", "TINY"),
+            ("base", "BASE"),
+            ("small_streaming", "SMALL_STREAMING"),
+            ("medium_streaming", "MEDIUM_STREAMING"),
+        ]:
+            t = Transcriber(model_size=model_size)
+
+            fake_arch = SimpleNamespace(
+                TINY="TINY",
+                BASE="BASE",
+                SMALL_STREAMING="SMALL_STREAMING",
+                MEDIUM_STREAMING="MEDIUM_STREAMING",
+            )
+            fake_transcriber_cls = MagicMock(return_value=MagicMock())
+            fake_get_model = MagicMock(return_value=("/fake/path", fake_arch.MEDIUM_STREAMING))
+
+            with patch.dict(
+                "sys.modules",
+                {
+                    "moonshine_voice": SimpleNamespace(
+                        ModelArch=fake_arch,
+                        Transcriber=fake_transcriber_cls,
+                        get_model_for_language=fake_get_model,
+                    )
+                },
+            ):
+                t._load_model()
+
+            call_kwargs = fake_transcriber_cls.call_args.kwargs
+            assert call_kwargs["model_path"] == "/fake/path"
+            assert call_kwargs["model_arch"] == arch_name
+
+    def test_unknown_model_size_falls_back_to_medium_streaming(self):
+        t = Transcriber(model_size="nonexistent_model")
+
+        fake_arch = SimpleNamespace(
+            TINY="TINY",
+            BASE="BASE",
+            SMALL_STREAMING="SMALL_STREAMING",
+            MEDIUM_STREAMING="MEDIUM_STREAMING",
+        )
+        fake_transcriber_cls = MagicMock(return_value=MagicMock())
+        fake_get_model = MagicMock(return_value=("/fake/path", None))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "moonshine_voice": SimpleNamespace(
+                    ModelArch=fake_arch,
+                    Transcriber=fake_transcriber_cls,
+                    get_model_for_language=fake_get_model,
+                )
+            },
+        ):
+            t._load_model()
+
+        call_kwargs = fake_transcriber_cls.call_args.kwargs
+        assert call_kwargs["model_arch"] == "MEDIUM_STREAMING"
 
 
-class TestResample:
-    def test_noop_when_rates_match(self):
-        audio = np.arange(100, dtype=np.float32)
-        result = _resample(audio, 16000, 16000)
-        np.testing.assert_array_equal(result, audio)
-
-    def test_upsample_doubles_length(self):
-        audio = np.ones(8000, dtype=np.float32)
-        result = _resample(audio, 8000, 16000)
-        assert len(result) == 16000
-
-    def test_downsample_halves_length(self):
-        audio = np.ones(16000, dtype=np.float32)
-        result = _resample(audio, 16000, 8000)
-        assert len(result) == 8000
-
-    def test_output_dtype_is_float32(self):
-        audio = np.ones(4000, dtype=np.float32)
-        result = _resample(audio, 8000, 16000)
-        assert result.dtype == np.float32
-
+# ---------------------------------------------------------------------------
+# _is_hallucination
+# ---------------------------------------------------------------------------
 
 class TestIsHallucination:
     def test_asa_repetition_detected(self):
@@ -117,6 +193,6 @@ class TestIsHallucination:
         assert _is_hallucination(text) is False
 
     def test_majority_single_token_flagged(self):
-        # Word "blah" makes up 9/11 tokens — above threshold.
+        # "blah" makes up 9/11 tokens — above threshold.
         text = "blah blah blah blah blah blah blah blah blah is fine"
         assert _is_hallucination(text) is True


### PR DESCRIPTION
## Summary

- Replace HuggingFace Whisper pipeline with **Moonshine Voice** `medium_streaming` (245M params, ~6.7% WER — beats Whisper Large-v3 at 1/6 the parameters, ~107ms on Apple Silicon)
- Overhaul LLM cleanup prompt with explicit self-correction rules, few-shot examples from real session output, and system/user role separation
- Add **user glossary** (`[glossary]` in config.toml) to fix STT-mangled proper nouns before the LLM sees them
- Improve rule-based fallback: word repetition removal, double-sorry removal
- Add interactive STT quality test script (`scripts/test_stt.py`)

## Commits

- `feat(stt)`: replace Whisper with Moonshine Voice medium_streaming
- `feat(cleanup)`: improve LLM prompt and add user glossary
- `chore(dev)`: add interactive STT quality test script

## Testing

77 tests passing (up from 65). New tests cover:
- Moonshine API (model arch mapping, hallucination guard, sample rate passthrough)
- Glossary substitution (case-insensitive, whole-word, multi-entry)
- Ollama system field presence
- Groq system role message
- Rule-based repetition and self-correction removal

## Config change

Users can now add to `~/.config/rawspeak/config.toml`:
```toml
[glossary]
"Jhunjhun" = "Zinjad"
"Suryabh"  = "Saurabh"
```

Refs: #12