### PR TITLE
feat(cleaner): improve LLM prompt quality and context injection

### DIFF
--- a/rawspeak/cleaner.py
+++ b/rawspeak/cleaner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import re
@@ -17,9 +18,12 @@ logger = logging.getLogger(__name__)
 # System-level instructions — used as the ``system`` role for Groq and as the
 # ``system`` field for Ollama /api/generate.
 _SYSTEM_PROMPT = """\
-You are a speech-to-text post-processor. Convert raw, imperfect voice \
-transcriptions into clean, professional text ready to send in an email, \
-message, or chat — or for an AI agent to act on.
+The input you receive was captured by speech-to-text software and may contain \
+STT-specific defects: mishearings, missing punctuation, run-on sentences, \
+spoken self-corrections, filler words, and accidental repetitions.
+
+Your job is to fix these defects and produce clean, professional text ready to \
+send in an email, message, or chat — or for an AI agent to act on.
 
 Rules:
 1. Fix all grammar and spelling errors.
@@ -29,15 +33,17 @@ capitalisation for every sentence.
 used as filler), sort of, kind of, I mean.
 4. Handle spoken self-corrections: when the speaker corrects themselves \
 ("X sorry Y", "X sorry sorry Y", "X I mean Y", "X wait Y", "X no Y"), \
-discard the error (X) and the correction marker, and keep only the intended \
-correction (Y).
+discard the error (X) and the correction marker, keep only the correction (Y).
 5. Remove false starts and accidental word repetitions \
 (e.g. "For for tomorrow" → "for tomorrow").
 6. Fix context-obvious mishearings using surrounding words \
 (e.g. "set all around for 1 a.m." → "set an alarm for 1 a.m.").
-7. Preserve the original meaning exactly — do NOT add, remove, or reorder \
+7. Apply spoken punctuation commands: if the speaker says "period", "comma", \
+"new paragraph", "open quote", or "close quote", apply the punctuation and \
+remove the command word from the output.
+8. Preserve the original meaning exactly — do NOT add, remove, or reorder \
 ideas. Do NOT summarise or paraphrase.
-8. Output ONLY the cleaned text — no explanation, no preamble, no surrounding \
+9. Output ONLY the cleaned text — no explanation, no preamble, no surrounding \
 quotes.
 
 Examples:
@@ -56,9 +62,6 @@ Input: "yes it did not work but I'll try again I want to set all around for \
 Output: Yes, it did not work, but I'll try again. I want to set an alarm for \
 1 a.m., and then I'm going to do something else.\
 """
-
-# User-turn template — the raw transcription handed to the model.
-_USER_TEMPLATE = "Raw transcription:\n{text}"
 
 
 class TextCleaner:
@@ -123,6 +126,25 @@ class TextCleaner:
 
         return _rule_based_clean(text)
 
+    def _build_user_content(self, text: str) -> str:
+        """Build the user-turn message with optional context hints.
+
+        Injects today's date and any user-glossary proper nouns so the LLM
+        can resolve date-relative expressions and preserve specialised names
+        it might otherwise normalise away.
+        """
+        context_lines: list[str] = [
+            f"Date: {datetime.date.today().isoformat()}",
+        ]
+        if self.user_glossary:
+            names = ", ".join(sorted(self.user_glossary.values()))
+            context_lines.append(
+                f"Proper nouns to preserve (spell exactly as shown): {names}"
+            )
+
+        context_block = "Context:\n" + "\n".join(f"- {l}" for l in context_lines)
+        return f"{context_block}\n\nRaw transcription:\n{text}"
+
     # ------------------------------------------------------------------
     # Backend implementations
     # ------------------------------------------------------------------
@@ -133,8 +155,9 @@ class TextCleaner:
         payload = {
             "model": self.ollama_model,
             "system": _SYSTEM_PROMPT,
-            "prompt": _USER_TEMPLATE.format(text=text),
+            "prompt": self._build_user_content(text),
             "stream": False,
+            "options": {"temperature": 0.1},
         }
         data = json.dumps(payload).encode()
         req = urllib.request.Request(
@@ -157,9 +180,9 @@ class TextCleaner:
             "model": self.groq_model,
             "messages": [
                 {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": _USER_TEMPLATE.format(text=text)},
+                {"role": "user", "content": self._build_user_content(text)},
             ],
-            "temperature": 0.3,
+            "temperature": 0.1,
             "max_tokens": 1024,
         }
         data = json.dumps(payload).encode()

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -74,7 +74,30 @@ class TestApplyGlossary:
         assert result == "Saurabh Zinjad"
 
 
-class TestTextCleanerNoneBackend:
+class TestBuildUserContent:
+    def test_includes_date(self):
+        import datetime
+        cleaner = TextCleaner(backend="none")
+        content = cleaner._build_user_content("hello")
+        assert datetime.date.today().isoformat() in content
+
+    def test_includes_transcription(self):
+        cleaner = TextCleaner(backend="none")
+        content = cleaner._build_user_content("test speech")
+        assert "test speech" in content
+
+    def test_includes_proper_nouns_from_glossary(self):
+        cleaner = TextCleaner(backend="none", user_glossary={"Jhunjhun": "Zinjad"})
+        content = cleaner._build_user_content("hello")
+        assert "Zinjad" in content
+
+    def test_no_glossary_omits_proper_noun_hint(self):
+        cleaner = TextCleaner(backend="none")
+        content = cleaner._build_user_content("hello")
+        assert "Proper nouns" not in content
+
+
+
     def test_uses_rule_based(self):
         cleaner = TextCleaner(backend="none")
         result = cleaner.clean("um hello uh world")
@@ -127,6 +150,24 @@ class TestTextCleanerOllamaBackend:
 
         assert "system" in captured[0]
         assert len(captured[0]["system"]) > 50  # non-trivial system prompt
+
+    def test_ollama_payload_temperature(self):
+        """Ollama request must set temperature=0.1 to prevent paraphrasing."""
+        cleaner = TextCleaner(backend="ollama")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"response": "ok"}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner._clean_ollama("test input")
+
+        assert captured[0].get("options", {}).get("temperature") == 0.1
 
     def test_falls_back_to_rule_based_on_error(self):
         cleaner = TextCleaner(backend="ollama")
@@ -200,6 +241,26 @@ class TestTextCleanerGroqBackend:
 
         roles = [m["role"] for m in captured[0]["messages"]]
         assert "system" in roles
+
+    def test_groq_payload_temperature(self):
+        """Groq request must set temperature=0.1."""
+        cleaner = TextCleaner(backend="groq", groq_api_key="test-key")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(
+                {"choices": [{"message": {"content": "ok"}}]}
+            ).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner._clean_groq("test input")
+
+        assert captured[0]["temperature"] == 0.1
 
     def test_falls_back_to_rule_based_on_error(self):
         cleaner = TextCleaner(backend="groq", groq_api_key="test-key")


### PR DESCRIPTION
## Summary

- Open `_SYSTEM_PROMPT` with STT-explicit framing — primes the LLM to fix STT-specific defects (mishearings, run-ons, self-corrections) rather than treating input as intentional writing
- Add spoken-punctuation rule: `"period"`, `"comma"`, `"new paragraph"` etc. are applied and stripped from output
- Replace static `_USER_TEMPLATE` with `_build_user_content()` — injects today's date and glossary proper nouns as a context block into every LLM call
- Set `temperature=0.1` for Ollama (was unset ~0.8) and Groq (was 0.3) to prevent paraphrasing
- 83/83 tests green (+6 new: `TestBuildUserContent`, `test_ollama_payload_temperature`, `test_groq_payload_temperature`)

## Issue

Refs: #12