### PR TITLE
feat(context): inject active app, clipboard, and per-app style into LLM cleanup

### DIFF
--- a/rawspeak/cleaner.py
+++ b/rawspeak/cleaner.py
@@ -9,6 +9,8 @@ import re
 import urllib.error
 import urllib.request
 
+from .context import STYLE_FOR_CATEGORY, get_app_category
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -45,6 +47,9 @@ remove the command word from the output.
 ideas. Do NOT summarise or paraphrase.
 9. Output ONLY the cleaned text — no explanation, no preamble, no surrounding \
 quotes.
+10. If a section is too garbled to reconstruct confidently, output your best \
+guess wrapped in [? ... ?] so the user knows to review it \
+(e.g. "[? Study size 1 pm ?]" → the user will correct it manually).
 
 Examples:
 
@@ -99,8 +104,22 @@ class TextCleaner:
     # Public API
     # ------------------------------------------------------------------
 
-    def clean(self, text: str) -> str:
+    def clean(
+        self,
+        text: str,
+        active_app: str = "",
+        clipboard_text: str = "",
+    ) -> str:
         """Return a cleaned version of *text*.
+
+        Args:
+            text:           Raw STT transcription to clean.
+            active_app:     Display name of the app the user is typing into
+                            (e.g. "Slack", "Mail", "Cursor").  Used to pick
+                            the right output style (casual vs formal vs code).
+            clipboard_text: Text already in the focused field/clipboard before
+                            recording started.  Gives the LLM context about
+                            what the user is appending to.
 
         Applies the user glossary first, then calls the configured LLM
         backend.  Falls back to rule-based cleanup when the backend fails.
@@ -112,30 +131,49 @@ class TextCleaner:
 
         if self.backend == "ollama":
             try:
-                return self._clean_ollama(text)
+                return self._clean_ollama(text, active_app, clipboard_text)
             except Exception as exc:
                 logger.warning("Ollama cleanup failed (%s); using rule-based fallback", exc)
                 return _rule_based_clean(text)
 
         if self.backend == "groq":
             try:
-                return self._clean_groq(text)
+                return self._clean_groq(text, active_app, clipboard_text)
             except Exception as exc:
                 logger.warning("Groq cleanup failed (%s); using rule-based fallback", exc)
                 return _rule_based_clean(text)
 
         return _rule_based_clean(text)
 
-    def _build_user_content(self, text: str) -> str:
-        """Build the user-turn message with optional context hints.
+    def _build_user_content(
+        self,
+        text: str,
+        active_app: str = "",
+        clipboard_text: str = "",
+    ) -> str:
+        """Build the user-turn message with runtime context hints.
 
-        Injects today's date and any user-glossary proper nouns so the LLM
-        can resolve date-relative expressions and preserve specialised names
-        it might otherwise normalise away.
+        Injects:
+        - Today's date (for resolving "tomorrow", "next Monday", etc.)
+        - Active app name + per-app style instruction
+        - Clipboard text (what the user is appending to)
+        - Glossary proper nouns (so the LLM never normalises them away)
         """
         context_lines: list[str] = [
             f"Date: {datetime.date.today().isoformat()}",
         ]
+
+        if active_app:
+            context_lines.append(f"Active app: {active_app}")
+            category = get_app_category(active_app)
+            style = STYLE_FOR_CATEGORY.get(category, "")
+            if style:
+                context_lines.append(f"Output style: {style}")
+
+        if clipboard_text:
+            preview = clipboard_text[:300].replace("\n", " ").strip()
+            context_lines.append(f"Text before cursor: \"{preview}\"")
+
         if self.user_glossary:
             names = ", ".join(sorted(self.user_glossary.values()))
             context_lines.append(
@@ -149,13 +187,18 @@ class TextCleaner:
     # Backend implementations
     # ------------------------------------------------------------------
 
-    def _clean_ollama(self, text: str) -> str:
+    def _clean_ollama(
+        self,
+        text: str,
+        active_app: str = "",
+        clipboard_text: str = "",
+    ) -> str:
         """Send *text* to a local Ollama server and return the response."""
         url = f"{self.ollama_url}/api/generate"
         payload = {
             "model": self.ollama_model,
             "system": _SYSTEM_PROMPT,
-            "prompt": self._build_user_content(text),
+            "prompt": self._build_user_content(text, active_app, clipboard_text),
             "stream": False,
             "options": {"temperature": 0.1},
         }
@@ -170,7 +213,12 @@ class TextCleaner:
             result = json.loads(resp.read().decode())
         return result.get("response", text).strip()
 
-    def _clean_groq(self, text: str) -> str:
+    def _clean_groq(
+        self,
+        text: str,
+        active_app: str = "",
+        clipboard_text: str = "",
+    ) -> str:
         """Send *text* to the Groq chat-completions API and return the response."""
         if not self.groq_api_key:
             raise ValueError("Groq API key not configured")
@@ -180,7 +228,7 @@ class TextCleaner:
             "model": self.groq_model,
             "messages": [
                 {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": self._build_user_content(text)},
+                {"role": "user", "content": self._build_user_content(text, active_app, clipboard_text)},
             ],
             "temperature": 0.1,
             "max_tokens": 1024,

--- a/rawspeak/context.py
+++ b/rawspeak/context.py
@@ -1,0 +1,150 @@
+"""Runtime context helpers — active app detection and clipboard snapshot.
+
+These are captured right before recording starts so the LLM cleaner knows:
+- *which app* the cleaned text will be pasted into (to pick the right style)
+- *what text* is already in that field (to match tone/continue a sentence)
+"""
+
+from __future__ import annotations
+
+import sys
+
+# ---------------------------------------------------------------------------
+# App → category mapping
+# ---------------------------------------------------------------------------
+
+# Maps known app display-names to a semantic category.
+# Matching is case-insensitive substring; first match wins.
+_APP_CATEGORY_MAP: list[tuple[str, str]] = [
+    # --- email ---
+    ("Mail", "email"),
+    ("Outlook", "email"),
+    ("Superhuman", "email"),
+    ("Mimestream", "email"),
+    ("Spark", "email"),
+    ("Airmail", "email"),
+    ("Thunderbird", "email"),
+    ("HEY", "email"),
+    # --- work messaging ---
+    ("Slack", "messaging"),
+    ("Discord", "messaging"),
+    ("Teams", "messaging"),
+    ("Telegram", "messaging"),
+    ("Signal", "messaging"),
+    ("WhatsApp", "messaging"),
+    ("Messages", "messaging"),
+    # --- code / terminal ---
+    ("Code", "code"),          # VS Code, Cursor (shows as "Code")
+    ("Cursor", "code"),
+    ("Windsurf", "code"),
+    ("Xcode", "code"),
+    ("PyCharm", "code"),
+    ("IntelliJ", "code"),
+    ("WebStorm", "code"),
+    ("RubyMine", "code"),
+    ("Sublime Text", "code"),
+    ("Zed", "code"),
+    ("vim", "code"),
+    ("nvim", "code"),
+    ("Terminal", "code"),
+    ("iTerm", "code"),
+    ("Warp", "code"),
+    ("Ghostty", "code"),
+    ("Alacritty", "code"),
+    # --- notes / writing ---
+    ("Notion", "notes"),
+    ("Obsidian", "notes"),
+    ("Bear", "notes"),
+    ("Typora", "notes"),
+    ("iA Writer", "notes"),
+    ("Craft", "notes"),
+    ("Ulysses", "notes"),
+    ("Notes", "notes"),
+    # --- browser ---
+    ("Safari", "browser"),
+    ("Chrome", "browser"),
+    ("Firefox", "browser"),
+    ("Arc", "browser"),
+    ("Brave", "browser"),
+    ("Edge", "browser"),
+    ("Opera", "browser"),
+]
+
+# Human-readable style instruction injected into the LLM user turn.
+STYLE_FOR_CATEGORY: dict[str, str] = {
+    "email": (
+        "Format for email: use full sentences, proper capitalisation, and "
+        "complete punctuation. Be clear and professional."
+    ),
+    "messaging": (
+        "Format for chat/messaging: keep it conversational. Contractions are "
+        "fine. Lighter punctuation is OK. No need for formal sentence structure."
+    ),
+    "code": (
+        "Format for a code editor or terminal: preserve technical terms, "
+        "variable names, camelCase, snake_case, and CLI commands exactly as "
+        "spoken. Avoid converting technical syntax into prose."
+    ),
+    "notes": (
+        "Format for notes or a writing app: clean sentences, standard "
+        "punctuation. Neither overly formal nor overly casual."
+    ),
+    "browser": (
+        "Format as clear, well-punctuated text suitable for a web form or "
+        "browser address bar."
+    ),
+}
+
+
+def get_app_category(app_name: str) -> str:
+    """Return the semantic category for *app_name*, or ``'other'``."""
+    name_lower = app_name.lower()
+    for fragment, category in _APP_CATEGORY_MAP:
+        if fragment.lower() in name_lower:
+            return category
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Active app detection
+# ---------------------------------------------------------------------------
+
+def get_active_app_name() -> str:
+    """Return the display name of the frontmost application.
+
+    Uses ``NSWorkspace`` on macOS (no special permissions required).
+    Returns an empty string on other platforms or on any error.
+    """
+    if sys.platform != "darwin":
+        return ""
+    try:
+        from AppKit import NSWorkspace  # type: ignore[import]
+
+        app = NSWorkspace.sharedWorkspace().frontmostApplication()
+        if app is None:
+            return ""
+        name = app.localizedName()
+        return str(name) if name else ""
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Clipboard snapshot
+# ---------------------------------------------------------------------------
+
+def get_clipboard_text(max_chars: int = 400) -> str:
+    """Return the current clipboard text, capped at *max_chars*.
+
+    Returns an empty string when the clipboard is empty, non-text, or on
+    any error.  We cap the length to keep the LLM prompt compact.
+    """
+    try:
+        import pyperclip  # already a rawspeak dependency
+
+        text = pyperclip.paste()
+        if isinstance(text, str) and text.strip():
+            return text[:max_chars]
+    except Exception:
+        pass
+    return ""

--- a/rawspeak/history.py
+++ b/rawspeak/history.py
@@ -3,35 +3,58 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import wave
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import List
 
+import numpy as np
+
 from .config import CONFIG_DIR
 
 HISTORY_FILE = CONFIG_DIR / "history.jsonl"
+AUDIO_DIR = CONFIG_DIR / "audio"
 
 
 @dataclass
 class HistoryEntry:
     timestamp: str
     text: str
+    audio_path: str = field(default="")
 
 
 class HistoryStore:
-    """Store and retrieve processed speech history as JSON lines."""
+    """Store and retrieve processed speech history as JSON lines.
+
+    Each entry can optionally reference a WAV file saved alongside the
+    text — useful for self-diagnosing STT quality issues (play back the
+    raw audio to hear exactly what the model received).
+    """
 
     def __init__(self, path: Path = HISTORY_FILE) -> None:
         self.path = path
 
-    def append(self, text: str) -> HistoryEntry:
+    def append(self, text: str, audio: np.ndarray | None = None, sample_rate: int = 16000) -> HistoryEntry:
+        """Persist *text* and an optional raw *audio* recording.
+
+        When *audio* is provided it is saved as a 16-bit PCM WAV file under
+        ``~/.config/rawspeak/audio/`` using a timestamp-based filename.
+        """
+        ts = datetime.now()
         entry = HistoryEntry(
-            timestamp=datetime.now().strftime("%I:%M %p").lstrip("0"),
+            timestamp=ts.strftime("%I:%M %p").lstrip("0"),
             text=text.strip(),
         )
         if not entry.text:
             return entry
+
+        if audio is not None and len(audio) > 0:
+            try:
+                audio_path = _save_wav(audio, sample_rate, ts)
+                entry.audio_path = str(audio_path)
+            except Exception:
+                pass  # audio saving is best-effort; don't break the pipeline
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("a", encoding="utf-8") as fh:
@@ -54,10 +77,34 @@ class HistoryStore:
                     timestamp = str(payload.get("timestamp", "")).strip()
                     if not text:
                         continue
-                    entries.append(HistoryEntry(timestamp=timestamp, text=text))
+                    entries.append(HistoryEntry(
+                        timestamp=timestamp,
+                        text=text,
+                        audio_path=str(payload.get("audio_path", "")),
+                    ))
                 except Exception:
                     continue
 
         if limit <= 0:
             return entries
         return entries[-limit:]
+
+
+# ---------------------------------------------------------------------------
+# WAV helpers
+# ---------------------------------------------------------------------------
+
+def _save_wav(audio: np.ndarray, sample_rate: int, ts: datetime) -> Path:
+    """Write *audio* as a 16-bit mono PCM WAV and return the path."""
+    AUDIO_DIR.mkdir(parents=True, exist_ok=True)
+    filename = ts.strftime("%Y%m%d_%H%M%S") + ".wav"
+    path = AUDIO_DIR / filename
+
+    pcm = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+    with wave.open(str(path), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)          # 16-bit
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+
+    return path

--- a/rawspeak/main.py
+++ b/rawspeak/main.py
@@ -9,6 +9,7 @@ import threading
 from .audio import AudioRecorder
 from .cleaner import TextCleaner
 from .config import load_config, write_default_config
+from .context import get_active_app_name, get_clipboard_text
 from .history import HistoryStore
 from .hotkey import HotkeyListener
 from .paste import Paster
@@ -75,6 +76,9 @@ class RawSpeak:
         self._processing = False
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
+        # Context snapshot captured at recording-start time.
+        self._active_app: str = ""
+        self._clipboard_text: str = ""
 
     # ------------------------------------------------------------------
     # Hotkey handler
@@ -93,6 +97,13 @@ class RawSpeak:
 
     def _start_recording(self) -> None:
         """Begin capturing audio (called with _lock held)."""
+        # Snapshot context NOW — the target app still has focus before we
+        # start recording.  This gives the LLM the right style + clipboard text.
+        self._active_app = get_active_app_name()
+        self._clipboard_text = get_clipboard_text()
+        logger.info("Context snapshot — app: %r  clipboard: %d chars",
+                    self._active_app, len(self._clipboard_text))
+
         try:
             self.recorder.start()
         except Exception:
@@ -139,11 +150,19 @@ class RawSpeak:
                 logger.info("Empty transcription — nothing to paste")
                 return
 
-            logger.info("Cleaning up text…")
-            cleaned = self.cleaner.clean(text)
+            logger.info("Cleaning up text (app=%r)…", self._active_app)
+            cleaned = self.cleaner.clean(
+                text,
+                active_app=self._active_app,
+                clipboard_text=self._clipboard_text,
+            )
             logger.info("Cleaned text: %r", cleaned)
 
-            entry = self.history.append(cleaned)
+            entry = self.history.append(
+                cleaned,
+                audio=audio,
+                sample_rate=self.config.sample_rate,
+            )
             if self.ui:
                 self.ui.enqueue(entry)
 

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -270,3 +270,104 @@ class TestTextCleanerGroqBackend:
 
         assert "um" not in result.lower()
         assert "test" in result.lower()
+
+
+class TestContextInjection:
+    """active_app and clipboard_text flow through to _build_user_content."""
+
+    def _make_cleaner(self):
+        return TextCleaner(backend="none")
+
+    def test_active_app_in_user_content(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", active_app="Slack")
+        assert "Slack" in content
+
+    def test_app_style_injected_for_known_app(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", active_app="Slack")
+        # messaging style should mention casual/conversational
+        assert "casual" in content.lower() or "conversational" in content.lower()
+
+    def test_email_app_injects_formal_style(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", active_app="Mail")
+        assert "formal" in content.lower() or "professional" in content.lower()
+
+    def test_code_app_injects_code_style(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", active_app="Cursor")
+        assert "camelCase" in content or "code" in content.lower()
+
+    def test_unknown_app_no_style_injected(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", active_app="FancyUnknownApp")
+        # Unknown apps have no style hint — but app name is still logged
+        assert "FancyUnknownApp" in content
+
+    def test_clipboard_text_in_user_content(self):
+        cleaner = self._make_cleaner()
+        content = cleaner._build_user_content("hello", clipboard_text="Dear team,")
+        assert "Dear team," in content
+
+    def test_clipboard_text_truncated(self):
+        cleaner = self._make_cleaner()
+        long_text = "x" * 1000
+        # _build_user_content itself clips at 300
+        content = cleaner._build_user_content("hello", clipboard_text=long_text)
+        # The pasted portion should be ≤300 chars of x's
+        assert "x" * 301 not in content
+
+    def test_clean_passes_active_app_to_ollama(self):
+        cleaner = TextCleaner(backend="ollama")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"response": "ok"}).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner.clean("test", active_app="Slack", clipboard_text="hi there")
+
+        prompt = captured[0]["prompt"]
+        assert "Slack" in prompt
+        assert "hi there" in prompt
+
+    def test_clean_passes_active_app_to_groq(self):
+        cleaner = TextCleaner(backend="groq", groq_api_key="test-key")
+        captured: list[dict] = []
+
+        def fake_urlopen(req, timeout=30):
+            captured.append(json.loads(req.data.decode()))
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(
+                {"choices": [{"message": {"content": "ok"}}]}
+            ).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            cleaner.clean("test", active_app="Mail", clipboard_text="Subject: hello")
+
+        user_msg = next(
+            m["content"] for m in captured[0]["messages"] if m["role"] == "user"
+        )
+        assert "Mail" in user_msg
+        assert "Subject: hello" in user_msg
+
+
+class TestUncertaintyRule:
+    """System prompt must contain the uncertainty flagging instruction."""
+
+    def test_system_prompt_mentions_uncertainty_brackets(self):
+        from rawspeak.cleaner import _SYSTEM_PROMPT
+        assert "[?" in _SYSTEM_PROMPT
+
+    def test_system_prompt_has_ten_rules(self):
+        from rawspeak.cleaner import _SYSTEM_PROMPT
+        assert "10." in _SYSTEM_PROMPT

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,120 @@
+"""Tests for rawspeak.context — app detection, category mapping, clipboard."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rawspeak.context import (
+    STYLE_FOR_CATEGORY,
+    get_active_app_name,
+    get_app_category,
+    get_clipboard_text,
+)
+
+
+class TestGetAppCategory:
+    def test_slack_is_messaging(self):
+        assert get_app_category("Slack") == "messaging"
+
+    def test_mail_is_email(self):
+        assert get_app_category("Mail") == "email"
+
+    def test_outlook_is_email(self):
+        assert get_app_category("Microsoft Outlook") == "email"
+
+    def test_cursor_is_code(self):
+        assert get_app_category("Cursor") == "code"
+
+    def test_vscode_is_code(self):
+        assert get_app_category("Code") == "code"
+
+    def test_terminal_is_code(self):
+        assert get_app_category("Terminal") == "code"
+
+    def test_iterm_is_code(self):
+        assert get_app_category("iTerm2") == "code"
+
+    def test_notion_is_notes(self):
+        assert get_app_category("Notion") == "notes"
+
+    def test_safari_is_browser(self):
+        assert get_app_category("Safari") == "browser"
+
+    def test_chrome_is_browser(self):
+        assert get_app_category("Google Chrome") == "browser"
+
+    def test_unknown_app_is_other(self):
+        assert get_app_category("FancyUnknownApp") == "other"
+
+    def test_case_insensitive(self):
+        assert get_app_category("slack") == "messaging"
+        assert get_app_category("SLACK") == "messaging"
+
+
+class TestStyleForCategory:
+    def test_all_categories_have_styles(self):
+        for cat in ("email", "messaging", "code", "notes", "browser"):
+            assert cat in STYLE_FOR_CATEGORY
+            assert len(STYLE_FOR_CATEGORY[cat]) > 20
+
+    def test_email_style_mentions_formal(self):
+        assert "formal" in STYLE_FOR_CATEGORY["email"].lower() or \
+               "professional" in STYLE_FOR_CATEGORY["email"].lower()
+
+    def test_messaging_style_mentions_conversational(self):
+        assert "conversational" in STYLE_FOR_CATEGORY["messaging"].lower() or \
+               "casual" in STYLE_FOR_CATEGORY["messaging"].lower()
+
+    def test_code_style_mentions_camelcase(self):
+        assert "camelCase" in STYLE_FOR_CATEGORY["code"] or \
+               "camel" in STYLE_FOR_CATEGORY["code"].lower()
+
+
+class TestGetActiveAppName:
+    def test_returns_string_on_non_macos(self):
+        with patch.object(sys, "platform", "linux"):
+            result = get_active_app_name()
+        assert isinstance(result, str)
+        assert result == ""
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
+    def test_returns_nonempty_string_on_macos(self):
+        result = get_active_app_name()
+        assert isinstance(result, str)
+        # We're running under a Python process — some app name should be returned.
+        # We can't assert the exact value but it should be non-empty in CI.
+
+    def test_returns_empty_on_nsworkspace_error(self):
+        with patch("rawspeak.context.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            with patch.dict("sys.modules", {"AppKit": None}):
+                # ImportError path — returns ""
+                result = get_active_app_name()
+        # Either returns "" (ImportError) or a real value; just check type.
+        assert isinstance(result, str)
+
+
+class TestGetClipboardText:
+    def test_returns_clipboard_content(self):
+        with patch("pyperclip.paste", return_value="hello world"):
+            result = get_clipboard_text()
+        assert result == "hello world"
+
+    def test_truncates_to_max_chars(self):
+        long_text = "x" * 1000
+        with patch("pyperclip.paste", return_value=long_text):
+            result = get_clipboard_text(max_chars=100)
+        assert len(result) == 100
+
+    def test_returns_empty_on_empty_clipboard(self):
+        with patch("pyperclip.paste", return_value="   "):
+            result = get_clipboard_text()
+        assert result == ""
+
+    def test_returns_empty_on_error(self):
+        with patch("pyperclip.paste", side_effect=Exception("clipboard error")):
+            result = get_clipboard_text()
+        assert result == ""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,120 @@
+"""Tests for rawspeak.history — HistoryStore and audio WAV saving."""
+
+from __future__ import annotations
+
+import json
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rawspeak.history import HistoryEntry, HistoryStore, _save_wav
+
+
+class TestHistoryEntry:
+    def test_default_audio_path_is_empty(self):
+        entry = HistoryEntry(timestamp="1:00 PM", text="hello")
+        assert entry.audio_path == ""
+
+    def test_audio_path_can_be_set(self):
+        entry = HistoryEntry(timestamp="1:00 PM", text="hello", audio_path="/tmp/x.wav")
+        assert entry.audio_path == "/tmp/x.wav"
+
+
+class TestHistoryStore:
+    def test_append_returns_entry(self, tmp_path):
+        store = HistoryStore(path=tmp_path / "history.jsonl")
+        entry = store.append("hello world")
+        assert entry.text == "hello world"
+        assert entry.timestamp
+
+    def test_append_saves_audio_path_when_audio_given(self, tmp_path):
+        store = HistoryStore(path=tmp_path / "history.jsonl")
+        audio = np.zeros(16000, dtype=np.float32)
+        entry = store.append("hello", audio=audio, sample_rate=16000)
+        assert entry.audio_path != ""
+        assert entry.audio_path.endswith(".wav")
+        assert Path(entry.audio_path).exists()
+
+    def test_append_no_audio_path_when_no_audio(self, tmp_path):
+        store = HistoryStore(path=tmp_path / "history.jsonl")
+        entry = store.append("hello")
+        assert entry.audio_path == ""
+
+    def test_audio_path_persisted_in_jsonl(self, tmp_path):
+        store = HistoryStore(path=tmp_path / "history.jsonl")
+        audio = np.zeros(16000, dtype=np.float32)
+        entry = store.append("hello", audio=audio, sample_rate=16000)
+
+        line = (tmp_path / "history.jsonl").read_text().strip()
+        payload = json.loads(line)
+        assert payload["audio_path"] == entry.audio_path
+
+    def test_list_recent_reads_audio_path(self, tmp_path):
+        store = HistoryStore(path=tmp_path / "history.jsonl")
+        audio = np.zeros(16000, dtype=np.float32)
+        store.append("hello", audio=audio, sample_rate=16000)
+
+        entries = store.list_recent()
+        assert len(entries) == 1
+        assert entries[0].audio_path.endswith(".wav")
+
+    def test_list_recent_handles_missing_audio_path(self, tmp_path):
+        """Old history entries without audio_path should still load."""
+        hist_file = tmp_path / "history.jsonl"
+        hist_file.write_text(
+            json.dumps({"timestamp": "1:00 PM", "text": "old entry"}) + "\n"
+        )
+        store = HistoryStore(path=hist_file)
+        entries = store.list_recent()
+        assert len(entries) == 1
+        assert entries[0].audio_path == ""
+
+    def test_append_empty_text_does_not_write(self, tmp_path):
+        hist_file = tmp_path / "history.jsonl"
+        store = HistoryStore(path=hist_file)
+        store.append("   ")
+        assert not hist_file.exists()
+
+
+class TestSaveWav:
+    def test_creates_valid_wav_file(self, tmp_path):
+        from datetime import datetime
+        audio = np.linspace(-0.5, 0.5, 16000, dtype=np.float32)
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+
+        # Temporarily redirect AUDIO_DIR to tmp_path
+        import rawspeak.history as hist_mod
+        original_audio_dir = hist_mod.AUDIO_DIR
+        hist_mod.AUDIO_DIR = tmp_path
+        try:
+            path = _save_wav(audio, 16000, ts)
+        finally:
+            hist_mod.AUDIO_DIR = original_audio_dir
+
+        assert path.exists()
+        with wave.open(str(path)) as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2  # 16-bit
+            assert wf.getframerate() == 16000
+
+    def test_clips_audio_before_saving(self, tmp_path):
+        """Audio values outside [-1, 1] must be clipped, not wrapped."""
+        from datetime import datetime
+        audio = np.array([2.0, -3.0, 0.5], dtype=np.float32)
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+
+        import rawspeak.history as hist_mod
+        original_audio_dir = hist_mod.AUDIO_DIR
+        hist_mod.AUDIO_DIR = tmp_path
+        try:
+            path = _save_wav(audio, 16000, ts)
+        finally:
+            hist_mod.AUDIO_DIR = original_audio_dir
+
+        with wave.open(str(path)) as wf:
+            raw = wf.readframes(wf.getnframes())
+        samples = np.frombuffer(raw, dtype=np.int16)
+        assert samples[0] == 32767   # 2.0 clipped to 1.0 → 32767
+        assert samples[1] == -32767  # -3.0 clipped to -1.0 → -32767


### PR DESCRIPTION
## Summary

- **New `rawspeak/context.py`**: `get_active_app_name()` via `NSWorkspace` (no permissions needed), `get_clipboard_text()`, `get_app_category()`, and `STYLE_FOR_CATEGORY` map covering email / messaging / code / notes / browser
- **`cleaner.py`**: `clean()` gains `active_app` + `clipboard_text` params; `_build_user_content()` injects app name, per-app style instruction, and text-before-cursor into every LLM call; Rule 10 added — garbled STT output surfaces as `[? ... ?]` instead of silently pasting garbage
- **`main.py`**: context snapshotted at recording-start (target app still has focus); raw audio passed to history for WAV saving
- **`history.py`**: `HistoryEntry.audio_path` field; `append()` saves 16-bit PCM WAV to `~/.config/rawspeak/audio/`; fully backward-compatible with old entries
- 128/128 tests green (+45 new across `test_context.py`, `test_history.py`, `test_cleaner.py`)

## Effect

When dictating into Slack → LLM gets "Format for chat/messaging: keep it conversational"
When dictating into Mail → "Format for email: be clear and professional"
When dictating into Cursor/VS Code → "Preserve camelCase, snake_case, CLI commands exactly"

Garbled STT output like `"Study size 1 pm"` now renders as `[? Study size 1 pm ?]` so the user sees exactly what to fix.

## Issue

Refs: #12